### PR TITLE
fix(client): use correct OAuth credentials and handle gzip responses

### DIFF
--- a/internal/client/eightsleep.go
+++ b/internal/client/eightsleep.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -120,8 +121,8 @@ func (c *Client) authTokenEndpoint(ctx context.Context) error {
 		"grant_type":    "password",
 		"username":      c.Email,
 		"password":      c.Password,
-		"client_id":     "sleep-client",
-		"client_secret": "",
+		"client_id":     c.ClientID,
+		"client_secret": c.ClientSecret,
 	}
 	body, _ := json.Marshal(payload)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, bytes.NewReader(body))
@@ -288,6 +289,15 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 		return err
 	}
 	defer resp.Body.Close()
+	var bodyReader io.Reader = resp.Body
+	if resp.Header.Get("Content-Encoding") == "gzip" {
+		gr, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return err
+		}
+		defer gr.Close()
+		bodyReader = gr
+	}
 	if resp.StatusCode == http.StatusTooManyRequests {
 		time.Sleep(2 * time.Second)
 		return c.do(ctx, method, path, query, body, out)
@@ -301,11 +311,11 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 		return c.do(ctx, method, path, query, body, out)
 	}
 	if resp.StatusCode >= 300 {
-		b, _ := io.ReadAll(resp.Body)
+		b, _ := io.ReadAll(bodyReader)
 		return fmt.Errorf("api %s %s: %s", method, path, string(b))
 	}
 	if out != nil {
-		return json.NewDecoder(resp.Body).Decode(out)
+		return json.NewDecoder(bodyReader).Decode(out)
 	}
 	return nil
 }

--- a/internal/client/eightsleep_test.go
+++ b/internal/client/eightsleep_test.go
@@ -104,49 +104,6 @@ func Test429Retry(t *testing.T) {
 	}
 }
 
-func TestAuthTokenEndpointUsesConfiguredCredentials(t *testing.T) {
-	var gotClientID, gotClientSecret string
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/tokens", func(w http.ResponseWriter, r *http.Request) {
-		var payload map[string]string
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Fatalf("decode: %v", err)
-		}
-		gotClientID = payload["client_id"]
-		gotClientSecret = payload["client_secret"]
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"access_token": "test-token",
-			"expires_in":   3600,
-			"userId":       "uid-1",
-		})
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	// Patch authURL for test by using authTokenEndpoint indirectly —
-	// we can't override the const, so instead test via New() defaults.
-	c := New("user@test.com", "pass", "", "", "")
-
-	// Verify defaults are the app credentials, not "sleep-client"
-	if c.ClientID == "sleep-client" || c.ClientID == "" {
-		t.Fatalf("expected default app client ID, got %q", c.ClientID)
-	}
-	if c.ClientSecret == "" {
-		t.Fatalf("expected default app client secret to be non-empty")
-	}
-
-	// Also verify custom credentials pass through
-	c2 := New("user@test.com", "pass", "", "custom-id", "custom-secret")
-	if c2.ClientID != "custom-id" || c2.ClientSecret != "custom-secret" {
-		t.Fatalf("custom credentials not preserved: got %q / %q", c2.ClientID, c2.ClientSecret)
-	}
-	_ = gotClientID
-	_ = gotClientSecret
-}
-
 func TestDoHandlesGzipResponse(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/gzipped", func(w http.ResponseWriter, r *http.Request) {
@@ -174,26 +131,3 @@ func TestDoHandlesGzipResponse(t *testing.T) {
 	}
 }
 
-func TestDoHandlesPlainResponse(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/plain", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"hello": "plain"})
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	c := New("email", "pass", "uid", "", "")
-	c.BaseURL = srv.URL
-	c.token = "t"
-	c.tokenExp = time.Now().Add(time.Hour)
-	c.HTTP = srv.Client()
-
-	var out map[string]string
-	if err := c.do(context.Background(), http.MethodGet, "/plain", nil, nil, &out); err != nil {
-		t.Fatalf("do plain: %v", err)
-	}
-	if out["hello"] != "plain" {
-		t.Fatalf("expected {hello: plain}, got %v", out)
-	}
-}

--- a/internal/client/eightsleep_test.go
+++ b/internal/client/eightsleep_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -99,5 +101,99 @@ func Test429Retry(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed < 2*time.Second {
 		t.Fatalf("expected backoff, got %v", elapsed)
+	}
+}
+
+func TestAuthTokenEndpointUsesConfiguredCredentials(t *testing.T) {
+	var gotClientID, gotClientSecret string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/tokens", func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		gotClientID = payload["client_id"]
+		gotClientSecret = payload["client_secret"]
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"userId":       "uid-1",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Patch authURL for test by using authTokenEndpoint indirectly —
+	// we can't override the const, so instead test via New() defaults.
+	c := New("user@test.com", "pass", "", "", "")
+
+	// Verify defaults are the app credentials, not "sleep-client"
+	if c.ClientID == "sleep-client" || c.ClientID == "" {
+		t.Fatalf("expected default app client ID, got %q", c.ClientID)
+	}
+	if c.ClientSecret == "" {
+		t.Fatalf("expected default app client secret to be non-empty")
+	}
+
+	// Also verify custom credentials pass through
+	c2 := New("user@test.com", "pass", "", "custom-id", "custom-secret")
+	if c2.ClientID != "custom-id" || c2.ClientSecret != "custom-secret" {
+		t.Fatalf("custom credentials not preserved: got %q / %q", c2.ClientID, c2.ClientSecret)
+	}
+	_ = gotClientID
+	_ = gotClientSecret
+}
+
+func TestDoHandlesGzipResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/gzipped", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		gz := gzip.NewWriter(w)
+		json.NewEncoder(gz).Encode(map[string]string{"hello": "world"})
+		gz.Close()
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New("email", "pass", "uid", "", "")
+	c.BaseURL = srv.URL
+	c.token = "t"
+	c.tokenExp = time.Now().Add(time.Hour)
+	c.HTTP = srv.Client()
+
+	var out map[string]string
+	if err := c.do(context.Background(), http.MethodGet, "/gzipped", nil, nil, &out); err != nil {
+		t.Fatalf("do gzip: %v", err)
+	}
+	if out["hello"] != "world" {
+		t.Fatalf("expected {hello: world}, got %v", out)
+	}
+}
+
+func TestDoHandlesPlainResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/plain", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"hello": "plain"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New("email", "pass", "uid", "", "")
+	c.BaseURL = srv.URL
+	c.token = "t"
+	c.tokenExp = time.Now().Add(time.Hour)
+	c.HTTP = srv.Client()
+
+	var out map[string]string
+	if err := c.do(context.Background(), http.MethodGet, "/plain", nil, nil, &out); err != nil {
+		t.Fatalf("do plain: %v", err)
+	}
+	if out["hello"] != "plain" {
+		t.Fatalf("expected {hello: plain}, got %v", out)
 	}
 }


### PR DESCRIPTION
## Problem

Two bugs in the API client that make `eightctl` permanently fail with 429 errors:

### 1. Wrong OAuth credentials in token endpoint

`authTokenEndpoint()` hardcodes `client_id: "sleep-client"` with an empty `client_secret` instead of using the actual app credentials (`c.ClientID` / `c.ClientSecret` — the ones extracted from the Eight Sleep Android app).

The auth server rejects this with a 400 (Joi validation fails on the empty secret), which falls through to `authLegacyLogin()`. By that point, the rate limiter has already been tripped → **permanent 429 loop**.

### 2. Gzip responses not decompressed

`do()` sends `Accept-Encoding: gzip` but never decompresses the response body, causing:
```
Error: invalid character '\\x1f' looking for beginning of value
```
(`0x1f` is the gzip magic byte.)

## Fix

- Use `c.ClientID` and `c.ClientSecret` in the token endpoint payload
- Decompress gzip responses when `Content-Encoding: gzip` is present
- Added tests for both fixes

Tested against a live Pod 5 — both auth and API calls work correctly after the fix.

Fixes #7, fixes #8, fixes #12