### PR TITLE
fix(metrics): send metrics=all for summary and aggregate

### DIFF
--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -37,8 +37,10 @@ func (m *MetricsActions) Summary(ctx context.Context, out any) error {
 	if err := m.c.requireUser(ctx); err != nil {
 		return err
 	}
+	q := url.Values{}
+	q.Set("metrics", "all")
 	path := fmt.Sprintf("/users/%s/metrics/summary", m.c.UserID)
-	return m.c.do(ctx, http.MethodGet, path, nil, nil, out)
+	return m.c.do(ctx, http.MethodGet, path, q, nil, out)
 }
 
 func (m *MetricsActions) Aggregate(ctx context.Context, out any) error {
@@ -47,6 +49,7 @@ func (m *MetricsActions) Aggregate(ctx context.Context, out any) error {
 	}
 	q := url.Values{}
 	q.Set("v2", "true")
+	q.Set("metrics", "all")
 	path := fmt.Sprintf("/users/%s/metrics/aggregate", m.c.UserID)
 	return m.c.do(ctx, http.MethodGet, path, q, nil, out)
 }

--- a/internal/client/metrics_test.go
+++ b/internal/client/metrics_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestMetricsSummaryIncludesDefaultMetrics(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/uid/metrics/summary", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("metrics"); got != "all" {
+			t.Fatalf("expected metrics=all, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New("email", "pass", "uid", "", "")
+	c.BaseURL = srv.URL
+	c.token = "t"
+	c.tokenExp = time.Now().Add(time.Hour)
+	c.HTTP = srv.Client()
+
+	var out map[string]any
+	if err := c.Metrics().Summary(context.Background(), &out); err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+}
+
+func TestMetricsAggregateIncludesDefaultMetrics(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/uid/metrics/aggregate", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("metrics"); got != "all" {
+			t.Fatalf("expected metrics=all, got %q", got)
+		}
+		if got := r.URL.Query().Get("v2"); got != "true" {
+			t.Fatalf("expected v2=true, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New("email", "pass", "uid", "", "")
+	c.BaseURL = srv.URL
+	c.token = "t"
+	c.tokenExp = time.Now().Add(time.Hour)
+	c.HTTP = srv.Client()
+
+	var out map[string]any
+	if err := c.Metrics().Aggregate(context.Background(), &out); err != nil {
+		t.Fatalf("aggregate: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `metrics=all` by default for `metrics summary`
- add `metrics=all` by default for `metrics aggregate`
- keep the existing `v2=true` aggregate query intact
- add focused client regression tests for both request shapes

## Repro

```bash
eightctl metrics summary -v
eightctl metrics aggregate -v
```

Before this change, both endpoints could fail with:

```json
{
  "errors": {
    "metrics": ["The metrics field is required."]
  }
}
```

## Testing

```bash
go test ./internal/client
```

Closes #18
