### PR TITLE
Fix OAuth client credentials and gzip decoding

### DIFF
--- a/internal/client/eightsleep.go
+++ b/internal/client/eightsleep.go
@@ -120,8 +120,8 @@ func (c *Client) authTokenEndpoint(ctx context.Context) error {
 		"grant_type":    "password",
 		"username":      c.Email,
 		"password":      c.Password,
-		"client_id":     "sleep-client",
-		"client_secret": "",
+		"client_id":     c.ClientID,
+		"client_secret": c.ClientSecret,
 	}
 	body, _ := json.Marshal(payload)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, authURL, bytes.NewReader(body))
@@ -182,7 +182,6 @@ func (c *Client) authLegacyLogin(ctx context.Context) error {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Connection", "keep-alive")
 	req.Header.Set("User-Agent", "okhttp/4.9.3")
-	req.Header.Set("Accept-Encoding", "gzip")
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
 		return err
@@ -281,7 +280,6 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Connection", "keep-alive")
 	req.Header.Set("User-Agent", "okhttp/4.9.3")
-	req.Header.Set("Accept-Encoding", "gzip")
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary
- use the configured/default Eight Sleep OAuth client credentials for password-grant auth
- stop forcing `Accept-Encoding: gzip` so Go can transparently decode API responses

## Why
The current auth flow sends a hardcoded `sleep-client` payload with an empty client secret, which causes the OAuth token endpoint to fail and forces the CLI onto the legacy login fallback. In practice that fallback can get rate-limited with `429 Too Many Requests`.

After fixing the OAuth request, live status requests succeeded, but response decoding still failed because the client explicitly requested gzip and then attempted to JSON-decode compressed bytes directly. Removing the manual `Accept-Encoding` header lets Go handle decompression correctly.

## Verification
- `go test ./...`
- verified live `eightctl status` on macOS after rebuilding the binary