### PR TITLE
fix(cmd): read --date/--from/--to from cobra flags instead of viper

### DIFF
--- a/internal/cmd/sleep.go
+++ b/internal/cmd/sleep.go
@@ -24,7 +24,7 @@ var sleepDayCmd = &cobra.Command{
 		if err := requireAuthFields(); err != nil {
 			return err
 		}
-		date := viper.GetString("date")
+		date, _ := cmd.Flags().GetString("date")
 		if date == "" {
 			date = time.Now().Format("2006-01-02")
 		}
@@ -53,6 +53,5 @@ var sleepDayCmd = &cobra.Command{
 
 func init() {
 	sleepCmd.PersistentFlags().String("date", "", "date YYYY-MM-DD (default today)")
-	viper.BindPFlag("date", sleepCmd.PersistentFlags().Lookup("date"))
 	sleepCmd.AddCommand(sleepDayCmd)
 }

--- a/internal/cmd/sleep_range.go
+++ b/internal/cmd/sleep_range.go
@@ -19,8 +19,8 @@ var sleepRangeCmd = &cobra.Command{
 		if err := requireAuthFields(); err != nil {
 			return err
 		}
-		from := viper.GetString("from")
-		to := viper.GetString("to")
+		from, _ := cmd.Flags().GetString("from")
+		to, _ := cmd.Flags().GetString("to")
 		if from == "" || to == "" {
 			return fmt.Errorf("--from and --to are required")
 		}
@@ -66,8 +66,6 @@ var sleepRangeCmd = &cobra.Command{
 func init() {
 	sleepRangeCmd.Flags().String("from", "", "start date YYYY-MM-DD")
 	sleepRangeCmd.Flags().String("to", "", "end date YYYY-MM-DD")
-	viper.BindPFlag("from", sleepRangeCmd.Flags().Lookup("from"))
-	viper.BindPFlag("to", sleepRangeCmd.Flags().Lookup("to"))
 	if sleepCmd != nil {
 		sleepCmd.AddCommand(sleepRangeCmd)
 	}


### PR DESCRIPTION
## Summary

`sleep day --date 2026-02-14` ignores the flag and queries today's date instead. Same root cause as #20 (fixed in #31): `viper.BindPFlag` with generic key names like `"date"`, `"from"`, `"to"` registers them globally, so flags from different commands collide.

**Fix:** Read `--date`, `--from`, `--to` directly from `cmd.Flags()` and remove the stale `viper.BindPFlag` calls.

Closes #13

## Changes

| File | Change |
|------|--------|
| `internal/cmd/sleep.go` | Read `--date` from `cmd.Flags()`, remove viper binding |
| `internal/cmd/sleep_range.go` | Read `--from`/`--to` from `cmd.Flags()`, remove viper bindings |

## Test plan

- [ ] `eightctl sleep day --date 2026-04-10` queries April 10, not today
- [ ] `eightctl sleep day` (no flag) defaults to today
- [ ] `eightctl sleep range --from 2026-04-10 --to 2026-04-15` passes both dates correctly
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)