### PR TITLE
fix: cache OAuth across household userIDs; add --side to away

### DIFF
--- a/internal/client/eightsleep.go
+++ b/internal/client/eightsleep.go
@@ -183,7 +183,7 @@ func (c *Client) ensureToken(ctx context.Context) error {
 	}
 	// Trust cached tokens without server validation. If token is invalid,
 	// the server will return 401 and we'll clear cache + re-authenticate.
-	if cached, err := tokencache.Load(c.Identity(), c.UserID); err == nil {
+	if cached, err := tokencache.Load(c.Identity()); err == nil {
 		log.Debug("loaded token from cache", "expires_at", cached.ExpiresAt, "user_id", cached.UserID)
 		c.token = cached.Token
 		c.tokenExp = cached.ExpiresAt

--- a/internal/cmd/away.go
+++ b/internal/cmd/away.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -13,30 +14,42 @@ import (
 var awayCmd = &cobra.Command{
 	Use:   "away",
 	Short: "Away mode (vacation)",
-	Long:  "Activate or deactivate away mode. When away, the pod stops heating/cooling.\nDefaults to the authenticated user's side. Use --both for both sides.",
+	Long:  "Activate or deactivate away mode. When away, the pod stops heating/cooling.\nTarget a specific side with --side left|right|solo, a specific user with\n--target-user-id, or apply to every household member with --both.\nWith no flags, defaults to the authenticated user's side.",
 }
 
 var awayOnCmd = &cobra.Command{
 	Use:   "on",
 	Short: "Activate away mode",
-	RunE:  func(cmd *cobra.Command, args []string) error { return runAway(true) },
+	RunE:  func(cmd *cobra.Command, args []string) error { return runAway(cmd, true) },
 }
 
 var awayOffCmd = &cobra.Command{
 	Use:   "off",
 	Short: "Deactivate away mode",
-	RunE:  func(cmd *cobra.Command, args []string) error { return runAway(false) },
+	RunE:  func(cmd *cobra.Command, args []string) error { return runAway(cmd, false) },
 }
 
-func runAway(on bool) error {
+func runAway(cmd *cobra.Command, on bool) error {
 	if err := requireAuthFields(); err != nil {
 		return err
 	}
 	cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
 	ctx := context.Background()
-	both, _ := awayCmd.Flags().GetBool("both")
+	both, _ := cmd.Flags().GetBool("both")
 
-	if both {
+	target, err := resolveSelectedTarget(ctx, cmd, cl)
+	if err != nil {
+		return err
+	}
+
+	action := map[bool]string{true: "activated", false: "deactivated"}[on]
+	var scope string
+
+	switch {
+	case both:
+		if target != nil {
+			return fmt.Errorf("--both conflicts with --side/--target-user-id")
+		}
 		sides, err := cl.Device().Sides(ctx)
 		if err != nil {
 			return fmt.Errorf("fetching device sides: %w", err)
@@ -49,20 +62,22 @@ func runAway(on bool) error {
 				return fmt.Errorf("setting away for %s: %w", uid, err)
 			}
 		}
-	} else {
+		scope = "both sides"
+	case target != nil:
+		if err := cl.SetAwayMode(ctx, target.UserID, on); err != nil {
+			return fmt.Errorf("setting away for %s: %w", target.UserID, err)
+		}
+		scope = strings.TrimPrefix(targetSuffix(target), " for ")
+		if scope == "" {
+			scope = "selected target"
+		}
+	default:
 		if err := cl.SetAwayMode(ctx, "", on); err != nil {
 			return err
 		}
+		scope = "your side"
 	}
 
-	action := "activated"
-	if !on {
-		action = "deactivated"
-	}
-	scope := "your side"
-	if both {
-		scope = "both sides"
-	}
 	if !viper.GetBool("quiet") {
 		fmt.Printf("away mode %s (%s)\n", action, scope)
 	}
@@ -70,7 +85,9 @@ func runAway(on bool) error {
 }
 
 func init() {
-	awayCmd.PersistentFlags().Bool("both", false, "Apply to both sides of the pod")
+	awayCmd.PersistentFlags().Bool("both", false, "Apply to every household member")
+	addTargetingFlags(awayOnCmd, true)
+	addTargetingFlags(awayOffCmd, true)
 	awayCmd.AddCommand(awayOnCmd)
 	awayCmd.AddCommand(awayOffCmd)
 }

--- a/internal/cmd/away.go
+++ b/internal/cmd/away.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,7 +41,10 @@ func runAway(cmd *cobra.Command, on bool) error {
 		return err
 	}
 
-	action := map[bool]string{true: "activated", false: "deactivated"}[on]
+	action := "activated"
+	if !on {
+		action = "deactivated"
+	}
 	var scope string
 
 	switch {
@@ -67,7 +69,7 @@ func runAway(cmd *cobra.Command, on bool) error {
 		if err := cl.SetAwayMode(ctx, target.UserID, on); err != nil {
 			return fmt.Errorf("setting away for %s: %w", target.UserID, err)
 		}
-		scope = strings.TrimPrefix(targetSuffix(target), " for ")
+		scope = targetScope(target)
 		if scope == "" {
 			scope = "selected target"
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -122,8 +122,8 @@ func requireAuthFields() error {
 		viper.GetString("client_id"),
 		viper.GetString("client_secret"),
 	)
-	if cached, err := tokencache.Load(c.Identity(), viper.GetString("user_id")); err == nil {
-		if cached.UserID != "" {
+	if cached, err := tokencache.Load(c.Identity()); err == nil {
+		if cached.UserID != "" && viper.GetString("user_id") == "" {
 			viper.Set("user_id", cached.UserID)
 		}
 		return nil

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -62,3 +62,25 @@ func TestRequireAuthFieldsFailsWithoutCacheOrCreds(t *testing.T) {
 		t.Fatalf("expected missing credentials error")
 	}
 }
+
+// When an explicit user_id is already set (e.g. via --user-id or config),
+// the cached UserID must not overwrite it. Households share one cached token
+// across multiple userIDs, so clobbering would silently retarget commands.
+func TestRequireAuthFieldsDoesNotClobberExplicitUserID(t *testing.T) {
+	useTempKeyring(t)
+	resetViper(t)
+
+	viper.Set("user_id", "explicit-user")
+
+	cl := client.New("", "", "explicit-user", "", "")
+	if err := tokencache.Save(cl.Identity(), "tok", time.Now().Add(time.Hour), "cached-user"); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	if err := requireAuthFields(); err != nil {
+		t.Fatalf("requireAuthFields should pass with cache: %v", err)
+	}
+	if got := viper.GetString("user_id"); got != "explicit-user" {
+		t.Fatalf("explicit user_id was overwritten, got %q", got)
+	}
+}

--- a/internal/cmd/targeting.go
+++ b/internal/cmd/targeting.go
@@ -88,14 +88,25 @@ func resolveCommandTargetValues(ctx context.Context, cl *client.Client, targetUs
 }
 
 func targetSuffix(target *client.HouseholdUserTarget) string {
+	scope := targetScope(target)
+	if scope == "" {
+		return ""
+	}
+	return " for " + scope
+}
+
+// targetScope returns a human-readable label for a resolved target
+// ("side left", "user abc-123", or "" when nothing is selected). Useful when
+// the caller wants to compose the label into something other than a suffix.
+func targetScope(target *client.HouseholdUserTarget) string {
 	if target == nil {
 		return ""
 	}
 	if side := strings.TrimSpace(target.Side); side != "" {
-		return " for side " + side
+		return "side " + side
 	}
 	if target.UserID != "" {
-		return " for user " + target.UserID
+		return "user " + target.UserID
 	}
 	return ""
 }

--- a/internal/tokencache/tokencache.go
+++ b/internal/tokencache/tokencache.go
@@ -122,15 +122,20 @@ func trySetWith(opener func() (keyring.Keyring, error), item keyring.Item) error
 	return ring.Set(item)
 }
 
-func Load(id Identity, expectedUserID string) (*CachedToken, error) {
-	cached, err := loadFrom(openKeyring, id, expectedUserID)
+// Load returns the cached token for the given Identity, if present and unexpired.
+// Tokens are namespaced by Identity (base URL + client ID + email) — not by
+// UserID — because a single OAuth principal (email) can legitimately act on
+// multiple household userIDs. The cached UserID is informational metadata for
+// callers that want to recover "which userID was primary at auth time."
+func Load(id Identity) (*CachedToken, error) {
+	cached, err := loadFrom(openKeyring, id)
 	if err == nil {
 		return cached, nil
 	}
 	if err != keyring.ErrKeyNotFound {
 		log.Debug("primary keyring load failed", "error", err)
 	}
-	fallback, fallbackErr := loadFrom(openFileKeyring, id, expectedUserID)
+	fallback, fallbackErr := loadFrom(openFileKeyring, id)
 	if fallbackErr == nil {
 		return fallback, nil
 	}
@@ -140,7 +145,7 @@ func Load(id Identity, expectedUserID string) (*CachedToken, error) {
 	return nil, err
 }
 
-func loadFrom(opener func() (keyring.Keyring, error), id Identity, expectedUserID string) (*CachedToken, error) {
+func loadFrom(opener func() (keyring.Keyring, error), id Identity) (*CachedToken, error) {
 	ring, err := opener()
 	if err != nil {
 		log.Debug("keyring open failed (load)", "error", err)
@@ -175,9 +180,6 @@ func loadFrom(opener func() (keyring.Keyring, error), id Identity, expectedUserI
 	}
 	if time.Now().After(cached.ExpiresAt) {
 		_ = ring.Remove(key)
-		return nil, keyring.ErrKeyNotFound
-	}
-	if expectedUserID != "" && cached.UserID != "" && cached.UserID != expectedUserID {
 		return nil, keyring.ErrKeyNotFound
 	}
 	return &cached, nil

--- a/internal/tokencache/tokencache_test.go
+++ b/internal/tokencache/tokencache_test.go
@@ -40,7 +40,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	got, err := Load(id, "user-1")
+	got, err := Load(id)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -55,14 +55,24 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
-func TestLoadSkipsMismatchedUser(t *testing.T) {
+// Households share one OAuth principal (email) across multiple userIDs, so a
+// token saved under "user-a" must still satisfy Load when the current call is
+// targeting "user-b". Identity-level namespacing is the authoritative boundary.
+func TestLoadReturnsTokenRegardlessOfStoredUserID(t *testing.T) {
 	withTestKeyring(t)
 	id := Identity{BaseURL: "https://api.example.com", ClientID: "client-1"}
 	if err := Save(id, "token", time.Now().Add(time.Hour), "user-a"); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if _, err := Load(id, "user-b"); err != keyring.ErrKeyNotFound {
-		t.Fatalf("expected ErrKeyNotFound for mismatched user, got %v", err)
+	got, err := Load(id)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Token != "token" {
+		t.Errorf("token = %q, want token", got.Token)
+	}
+	if got.UserID != "user-a" {
+		t.Errorf("UserID metadata = %q, want user-a", got.UserID)
 	}
 }
 
@@ -72,11 +82,11 @@ func TestLoadExpiredRemovesEntry(t *testing.T) {
 	if err := Save(id, "expired", time.Now().Add(-time.Minute), "user-1"); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	if _, err := Load(id, "user-1"); err != keyring.ErrKeyNotFound {
+	if _, err := Load(id); err != keyring.ErrKeyNotFound {
 		t.Fatalf("expected ErrKeyNotFound for expired token, got %v", err)
 	}
 	// second load should still be ErrKeyNotFound (entry removed)
-	if _, err := Load(id, "user-1"); err != keyring.ErrKeyNotFound {
+	if _, err := Load(id); err != keyring.ErrKeyNotFound {
 		t.Fatalf("expected ErrKeyNotFound after removal, got %v", err)
 	}
 }
@@ -109,19 +119,16 @@ func TestNamespacingByIdentity(t *testing.T) {
 		t.Fatalf("Save D: %v", err)
 	}
 
-	if got, _ := Load(idA, "user-a"); got.Token != "token-a" {
+	if got, _ := Load(idA); got.Token != "token-a" {
 		t.Errorf("Load A token = %q, want token-a", got.Token)
 	}
-	if _, err := Load(idA, "user-b"); err != keyring.ErrKeyNotFound {
-		t.Errorf("Load A with user-b should miss, got %v", err)
-	}
-	if got, _ := Load(idB, "user-b"); got.Token != "token-b" {
+	if got, _ := Load(idB); got.Token != "token-b" {
 		t.Errorf("Load B token = %q, want token-b", got.Token)
 	}
-	if got, _ := Load(idC, "user-c"); got.Token != "token-c" {
+	if got, _ := Load(idC); got.Token != "token-c" {
 		t.Errorf("Load C token = %q, want token-c", got.Token)
 	}
-	if got, _ := Load(idD, ""); got.Token != "token-d" {
+	if got, _ := Load(idD); got.Token != "token-d" {
 		t.Errorf("Load D token = %q, want token-d", got.Token)
 	}
 }
@@ -141,10 +148,10 @@ func TestClearOnlyRemovesMatchingIdentity(t *testing.T) {
 	if err := Clear(idA); err != nil {
 		t.Fatalf("Clear A: %v", err)
 	}
-	if _, err := Load(idA, "user-a"); err != keyring.ErrKeyNotFound {
+	if _, err := Load(idA); err != keyring.ErrKeyNotFound {
 		t.Fatalf("expected A cleared, got %v", err)
 	}
-	if got, err := Load(idB, "user-b"); err != nil || got.Token != "token-b" {
+	if got, err := Load(idB); err != nil || got.Token != "token-b" {
 		t.Fatalf("B should remain, got %v err %v", got, err)
 	}
 }
@@ -174,7 +181,7 @@ func TestLoadWithoutEmailFindsSingleMatch(t *testing.T) {
 
 	// email omitted -> should still find the single token
 	idNoEmail := Identity{BaseURL: id.BaseURL, ClientID: id.ClientID}
-	cached, err := Load(idNoEmail, "user-1")
+	cached, err := Load(idNoEmail)
 	if err != nil {
 		t.Fatalf("Load without email: %v", err)
 	}
@@ -192,7 +199,7 @@ func TestLoadWithoutEmailMultipleMatchesFails(t *testing.T) {
 	if err := Save(Identity{BaseURL: common.BaseURL, ClientID: common.ClientID, Email: "b@example.com"}, "tb", time.Now().Add(time.Hour), "ub"); err != nil {
 		t.Fatalf("save b: %v", err)
 	}
-	if _, err := Load(common, ""); err != keyring.ErrKeyNotFound {
+	if _, err := Load(common); err != keyring.ErrKeyNotFound {
 		t.Fatalf("expected not found when multiple matches, got %v", err)
 	}
 }
@@ -237,7 +244,7 @@ func TestSaveFallsBackToFileWhenPrimarySetFails(t *testing.T) {
 		t.Fatalf("Save should fall back to file: %v", err)
 	}
 
-	got, err := Load(id, "u1")
+	got, err := Load(id)
 	if err != nil {
 		t.Fatalf("Load from file fallback: %v", err)
 	}


### PR DESCRIPTION
## Summary
- **Token cache**: `tokencache.Load` was rejecting a valid cached token whenever the currently-targeted userID differed from the one stored at auth time. Households share one OAuth principal across multiple userIDs, so running e.g. `eightctl away on` for one side then the other in separate invocations forced a fresh password-grant auth each time and tripped Eight Sleep's 429 rate limit. Tokens are now namespaced strictly by `Identity` (base URL + client ID + email); the cached `UserID` stays as informational metadata used to populate `c.UserID` when the caller didn't supply one.
- **Away symmetry**: `away on|off` now accepts `--side left|right|solo` and `--target-user-id`, matching `on`/`off`/`temp`/`status`. This removes the asymmetry where only the config-default side could be toggled without an explicit `--user-id`. `--both` still applies to every household member and now errors cleanly if combined with `--side`.

## Test plan
- [x] `go test ./...` — all green (tokencache + client + cmd)
- [x] `go build ./...` / `go vet ./...`
- [x] `eightctl away on --help` shows new `--side` / `--target-user-id` flags
- [ ] Run `eightctl away on --side left` and `eightctl away on --side right` back-to-back in separate invocations; verify no 429 and a single network auth in verbose mode
- [ ] Run `eightctl away on --both` and confirm both sides toggle without re-auth
- [ ] Run `eightctl away on` with no flags and confirm it still targets the authenticated user's side (unchanged default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)