### PR TITLE
chore(deps): refresh build tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -29,7 +29,7 @@ jobs:
           fi
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
           version: v2.12.2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -37,7 +37,7 @@ jobs:
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.2
+        uses: goreleaser/goreleaser-action@v7.2.3
         with:
           distribution: goreleaser
           version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ profile.cov
 # vendor/
 node_modules/
 
+# GoReleaser output
+dist/
+
 # Go workspace file
 go.work
 go.work.sum

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,13 +20,15 @@ builds:
       - windows_arm64
 
 archives:
-  - builds:
+  - ids:
       - eightctl
-    format: tar.gz
+    formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
 
 checksum:
   name_template: checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,10 @@ release history from git.
   and the current command surface.
 - Release automation now uses `.goreleaser.yaml`, supports tag backfills, and
   includes a Linux arm64 target.
+- Release packaging configuration now uses the current GoReleaser archive fields.
 - Lint configuration was prepared for golangci-lint v2.
-- Go module now targets Go 1.26.2 and tracks `gofumpt` with the Go tool
-  directive.
-- Dependencies and CI tooling were updated to current versions.
+- Go module now targets Go 1.26.4 and tracks `gofumpt` with the Go tool directive.
+- Dependencies and CI tooling were updated to current stable versions, including pnpm 11.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Priority: flags > env vars (`EIGHTCTL_*`) > config file.
 Key fields: `email`, `password`, optional `user_id`, `client_id`, `client_secret`, `timezone`, `output`, `fields`, `verbose`. The client auto-resolves `user_id` and `device_id` after authentication. Config file permissions are checked (warn if >0600).
 
 ## Tooling
-- Go: module targets Go 1.26.2 and lets `actions/setup-go` read `go.mod`.
+- Go: module targets Go 1.26.4 and lets `actions/setup-go` read `go.mod`.
 - Make: `make fmt` (tracked `go tool` gofumpt), `make lint` (golangci-lint), `make test`, `make coverage`.
 - Coverage: CI enforces >=85% on core packages (`internal/client`, `config`, `daemon`, `output`, `tokencache`); command wiring still runs through `go test ./...`.
 - CI: `.github/workflows/ci.yml` runs format, lint, tests, and the coverage gate.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/eightctl
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/99designs/keyring v1.2.2

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "eightctl": "go run ./cmd/eightctl",
     "start": "go run ./cmd/eightctl",


### PR DESCRIPTION
## Summary

- update Go to 1.26.4 and pnpm to 11.9.0
- refresh setup-go, golangci-lint-action, and goreleaser-action to current stable releases
- migrate GoReleaser archive settings away from deprecated fields and ignore local `dist/` output
- align README and unreleased changelog metadata

## Upstream checks

- Go stable: https://go.dev/dl/
- setup-go 6.5.0: https://github.com/actions/setup-go/releases/tag/v6.5.0
- golangci-lint-action 9.3.0: https://github.com/golangci/golangci-lint-action/releases/tag/v9.3.0
- goreleaser-action 7.2.3: https://github.com/goreleaser/goreleaser-action/releases/tag/v7.2.3
- GoReleaser archive migration: https://goreleaser.com/resources/deprecations/
- pnpm 11 migration: https://pnpm.io/11.x/migration

## Proof

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- core coverage: 85.1%
- `golangci-lint run ./...`
- `go mod verify`
- `govulncheck ./...`: no vulnerabilities
- pnpm 11.9.0 frozen install, test, and lint
- `actionlint`
- `goreleaser check`
- `goreleaser release --snapshot --clean`: all six configured platform archives built
- autoreview: clean after removing generated snapshot artifacts from the change bundle

## Risk

Low. Runtime source and public behavior are unchanged; risk is limited to CI/release tooling compatibility. The exact tool versions and full snapshot packaging path passed locally.
