### PR TITLE
docs: sync command specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ eightctl daemon --dry-run
 - **Alarms:** `alarm list|create|update|delete|snooze|dismiss|dismiss-all|vibration-test`
 - **Temperature modes:** `tempmode nap on|off|extend|status`, `tempmode hotflash on|off|status`, `tempmode events`
 - **Audio:** `audio tracks|categories|state|play|pause|seek|volume|pair|next`, `audio favorites list|add|remove`
-- **Base:** `base info|angle|presets|preset-run|vibration-test`
+- **Base:** `base info|angle|presets|preset-run|test`
 - **Device:** `device info|peripherals|owner|warranty|online|priming-tasks|priming-schedule`
 - **Metrics & insights:** `sleep day|range`, `presence [--from --to]`, `metrics trends|intervals|insights`
-- **Autopilot:** `autopilot details|history|recap`, `autopilot set-level-suggestions`, `autopilot set-snore-mitigation`
+- **Autopilot:** `autopilot details|history|recap`, `autopilot level-suggestions`, `autopilot snore-mitigation`
 - **Travel:** `travel trips|create-trip|delete-trip|plans|create-plan|update-plan|tasks|airport-search|flight-status`
 - **Household:** `household summary|schedule|current-set|invitations|devices|users|guests`
-- **Misc:** `tracks`, `feats`, `whoami`, `version`
+- **Misc:** `tracks`, `feats`, `whoami`, `logout`, `version`
 
 Use `--output table|json|csv` and `--fields field1,field2` to shape output. `--verbose` enables debug logs; `--quiet` hides the config banner.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -17,10 +17,13 @@ Eight Sleep Pod power/control + data-export CLI, written in Go. Targets macOS/Li
 - Permissions check warns if config is more permissive than `0600`.
 
 ## CLI Surface (implemented)
-Core: `on`, `off`, `temp <level>`, `status`, `whoami`, `version`.
+Core: `on`, `off`, `temp <level>`, `status`, `whoami`, `logout`, `version`.
+
+Away mode:
+- `away on|off`
 
 Schedules & daemon:
-- `schedule list|create|update|delete` (cloud temperature schedules)
+- `schedule list` (Autopilot smart schedule)
 - `daemon` (YAML-based scheduler with PID guard, dry-run, timezone override, optional state sync)
 
 Alarms:
@@ -34,9 +37,10 @@ Temperature modes & events:
 
 Audio:
 - `audio tracks|categories|state|play|pause|seek|volume|pair|next`
+- `audio favorites list|add|remove`
 
 Adjustable base:
-- `base info|angle|presets|preset-run|vibration-test`
+- `base info|angle|presets|preset-run|test`
 
 Device & maintenance:
 - `device info|peripherals|owner|warranty|online|priming-tasks|priming-schedule`
@@ -44,20 +48,18 @@ Device & maintenance:
 Metrics & insights:
 - `metrics trends --from --to`
 - `metrics intervals --id`
-- `metrics summary`
-- `metrics aggregate`
 - `metrics insights`
 - `sleep day --date`, `sleep range --from --to`
 - `presence [--from --to]`
 
 Autopilot:
 - `autopilot details|history|recap`
-- `autopilot set-level-suggestions --enabled`
-- `autopilot set-snore-mitigation --enabled`
+- `autopilot level-suggestions --enabled`
+- `autopilot snore-mitigation --enabled`
 
 Travel:
 - `travel trips|create-trip|delete-trip`
-- `travel plans --trip`
+- `travel plans|create-plan|update-plan`
 - `travel tasks --plan`
 - `travel airport-search --query`
 - `travel flight-status --flight`
@@ -73,6 +75,7 @@ Audio/temperature data helpers:
 - Logs via charmbracelet/log; `--verbose` for debug; `--quiet` hides config notice.
 - `status` should prefer discovered household targets when available and display `left` / `right` or inferred `solo`.
 - `on`, `off`, and `temp` should default to all discovered household targets unless narrowed with `--side` or `--target-user-id`.
+- `away` should default to the authenticated user's side, accept `--side` or `--target-user-id`, and use `--both` for the household.
 - `temp` accepts negative positional levels such as `temp -40` without requiring `--`.
 
 ## Daemon Behavior


### PR DESCRIPTION
## Summary

- remove retired schedule CRUD and metrics summary/aggregate commands from the specification
- document current away, audio favorites, travel plan, logout, base test, and Autopilot command names
- align README command names with Cobra's current command tree

## Proof

- compared README and `docs/spec.md` against current Cobra help and command registration
- `go test ./...`
- `git diff --check`
- autoreview skipped: documentation-only command inventory correction with source/help verification

## Risk

Low. Documentation only; no runtime behavior changes.
