### PR TITLE
fix(metrics): remove unavailable insights command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ release history from git.
 
 ### Removed
 
+- Removed unavailable `metrics insights` behavior after Eight Sleep endpoint changes; use `metrics trends` instead. Thanks @Abhijay.
 - Removed unavailable `metrics summary` and `metrics aggregate` behavior after
   Eight Sleep endpoint changes; use `metrics trends` instead.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ eightctl daemon --dry-run
 - **Audio:** `audio tracks|categories|state|play|pause|seek|volume|pair|next`, `audio favorites list|add|remove`
 - **Base:** `base info|angle|presets|preset-run|test`
 - **Device:** `device info|peripherals|owner|warranty|online|priming-tasks|priming-schedule`
-- **Metrics & insights:** `sleep day|range`, `presence [--from --to]`, `metrics trends|intervals|insights`
+- **Metrics:** `sleep day|range`, `presence [--from --to]`, `metrics trends|intervals`
 - **Autopilot:** `autopilot details|history|recap`, `autopilot level-suggestions`, `autopilot snore-mitigation`
 - **Travel:** `travel trips|create-trip|delete-trip|plans|create-plan|update-plan|tasks|airport-search|flight-status`
 - **Household:** `household summary|schedule|current-set|invitations|devices|users|guests`
@@ -76,7 +76,7 @@ Key fields: `email`, `password`, optional `user_id`, `client_id`, `client_secret
 - The API is undocumented and rate-limited; repeated logins can return 429. The client now mimics Android app headers and reuses tokens to reduce throttling, but cooldowns may still apply.
 - Authentication uses the OAuth2 password grant against `auth-api.8slp.net/v1/tokens` with `application/x-www-form-urlencoded` bodies. The legacy `/login` JSON endpoint is no longer called.
 - HTTPS only; no local/Bluetooth control exposed here.
-- Eight Sleep retired the temperature-schedules/routines CRUD API; `schedule list` now surfaces the Autopilot (smart) schedule from the `smart` subfield of `app-api.8slp.net/v1/users/:id/temperature`. `metrics summary` / `metrics aggregate` were removed because the underlying endpoints no longer exist — use `metrics trends` instead.
+- Eight Sleep retired the temperature-schedules/routines CRUD API; `schedule list` now surfaces the Autopilot (smart) schedule from the `smart` subfield of `app-api.8slp.net/v1/users/:id/temperature`. `metrics summary`, `metrics aggregate`, and `metrics insights` were removed because the underlying endpoints no longer exist — use `metrics trends` instead.
 - The `tz` query param rejects the literal strings `local` / `Local`. The client resolves `--timezone local` (the default) to a real IANA zone, falling back to `UTC` with a warning when the system has no zoneinfo.
 
 ## Prior Work / References

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -45,10 +45,9 @@ Adjustable base:
 Device & maintenance:
 - `device info|peripherals|owner|warranty|online|priming-tasks|priming-schedule`
 
-Metrics & insights:
+Metrics:
 - `metrics trends --from --to`
 - `metrics intervals --id`
-- `metrics insights`
 - `sleep day --date`, `sleep range --from --to`
 - `presence [--from --to]`
 

--- a/internal/client/action_data_test.go
+++ b/internal/client/action_data_test.go
@@ -33,14 +33,6 @@ func TestClientDataActionEndpoints(t *testing.T) {
 			want: recordedRequest{Method: http.MethodGet, Path: "/users/uid/intervals/session-1"},
 		},
 		{
-			name: "MetricsInsights",
-			call: func(ctx context.Context, c *Client) error {
-				var out any
-				return c.Metrics().Insights(ctx, &out)
-			},
-			want: recordedRequest{Method: http.MethodGet, Path: "/users/uid/insights"},
-		},
-		{
 			name: "GetSmartSchedule",
 			call: func(ctx context.Context, c *Client) error {
 				_, err := c.GetSmartSchedule(ctx)

--- a/internal/client/metrics.go
+++ b/internal/client/metrics.go
@@ -37,11 +37,3 @@ func (m *MetricsActions) Intervals(ctx context.Context, sessionID string, out an
 	path := fmt.Sprintf("/users/%s/intervals/%s", m.c.UserID, sessionID)
 	return m.c.do(ctx, http.MethodGet, path, nil, nil, out)
 }
-
-func (m *MetricsActions) Insights(ctx context.Context, out any) error {
-	if err := m.c.requireUser(ctx); err != nil {
-		return err
-	}
-	path := fmt.Sprintf("/users/%s/insights", m.c.UserID)
-	return m.c.do(ctx, http.MethodGet, path, nil, nil, out)
-}

--- a/internal/cmd/metrics.go
+++ b/internal/cmd/metrics.go
@@ -10,7 +10,14 @@ import (
 	"github.com/steipete/eightctl/internal/output"
 )
 
-var metricsCmd = &cobra.Command{Use: "metrics", Short: "Sleep metrics and insights"}
+var metricsCmd = &cobra.Command{
+	Use:   "metrics",
+	Short: "Sleep metrics",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	},
+}
 
 var metricsTrendsCmd = &cobra.Command{Use: "trends", RunE: func(cmd *cobra.Command, args []string) error {
 	if err := requireAuthFields(); err != nil {
@@ -52,22 +59,10 @@ var metricsIntervalsCmd = &cobra.Command{Use: "intervals", RunE: func(cmd *cobra
 	return output.Print(output.Format(viper.GetString("output")), []string{"interval"}, []map[string]any{{"interval": out}})
 }}
 
-var metricsInsightsCmd = &cobra.Command{Use: "insights", RunE: func(cmd *cobra.Command, args []string) error {
-	if err := requireAuthFields(); err != nil {
-		return err
-	}
-	cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
-	var out any
-	if err := cl.Metrics().Insights(context.Background(), &out); err != nil {
-		return err
-	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"insights"}, []map[string]any{{"insights": out}})
-}}
-
 func init() {
 	metricsTrendsCmd.Flags().String("from", "", "from date YYYY-MM-DD")
 	metricsTrendsCmd.Flags().String("to", "", "to date YYYY-MM-DD")
 	metricsIntervalsCmd.Flags().String("id", "", "session id")
 
-	metricsCmd.AddCommand(metricsTrendsCmd, metricsIntervalsCmd, metricsInsightsCmd)
+	metricsCmd.AddCommand(metricsTrendsCmd, metricsIntervalsCmd)
 }

--- a/internal/cmd/metrics_test.go
+++ b/internal/cmd/metrics_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "testing"
+
+func TestMetricsInsightsCommandIsNotRegistered(t *testing.T) {
+	for _, command := range metricsCmd.Commands() {
+		if command.Name() == "insights" {
+			t.Fatal("unsupported metrics insights command is registered")
+		}
+	}
+
+	if err := metricsCmd.Args(metricsCmd, []string{"insights"}); err == nil {
+		t.Fatal("unsupported metrics insights argument is accepted")
+	}
+	if metricsCmd.RunE == nil {
+		t.Fatal("metrics command skips argument validation without a runner")
+	}
+}


### PR DESCRIPTION
## Summary

- remove the unavailable metrics insights command and client endpoint wrapper
- reject retired metrics command names with a nonzero unknown-command error
- update the README, specification, changelog, and command regression coverage

Fixes #42.

## Proof

- `go test ./...` — passed
- `make coverage` — passed; core coverage 85.1%
- `golangci-lint run --allow-parallel-runners ./...` — 0 issues
- `go run github.com/goreleaser/goreleaser/v2@v2.17.0 check` — configuration valid
- built the real CLI with `go build -o /private/tmp/eightctl-issue-42 ./cmd/eightctl`
- `/private/tmp/eightctl-issue-42 metrics --help` — lists only `intervals` and `trends`
- `/private/tmp/eightctl-issue-42 metrics insights` — exits 1 with an unknown-command error before authentication
- `/private/tmp/eightctl-issue-42 metrics trends --help` and `metrics intervals --help` — both exit 0
- autoreview local — clean; no accepted/actionable findings
