### PR TITLE
chore(deps): refresh release dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.13.1",
   "scripts": {
     "eightctl": "go run ./cmd/eightctl",
     "start": "go run ./cmd/eightctl",


### PR DESCRIPTION
## Summary

- update pnpm from 11.12.0 to 11.13.1
- update `actions/setup-go` from 6.5.0 to 7.0.0 in CI and release workflows
- confirm every direct Go module and remaining build/release pin is already current

## Proof

- `go test ./...` — passed
- `make coverage` — passed; core coverage 85.1%
- `golangci-lint run --allow-parallel-runners ./...` — 0 issues
- `actionlint` — passed
- `npx --yes pnpm@11.13.1 test` — passed
- real binary build and version smoke — `0.2.0-dev`
- release-notes extraction — passed
- GoReleaser 2.17 configuration check — passed
- autoreview local — clean; no accepted/actionable findings
