### PR TITLE
chore(release): use unified pipeline alpha.4

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.2
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.4
     with:
       version: ${{ inputs.version }}
       repository-type: personal


### PR DESCRIPTION
Updates the unified release caller to alpha.4 for safe retries against the already-frozen 0.2.1 tag.