### PR TITLE
chore: open Unreleased section after 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier project history from git.
 
+## Unreleased
+
 ## 0.2.1 - 2026-07-17
 
 ### Highlights


### PR DESCRIPTION
Closeout for v0.2.1 (pipeline closeout stage was blocked by the Actions PR-creation setting, now enabled).