### PR TITLE
ci: bump unified release workflow to alpha.12

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.11
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.12
     with:
       version: ${{ inputs.version }}
       repository-type: personal


### PR DESCRIPTION
## Summary

- bump the unified release caller from `v1.0.0-alpha.11` to `v1.0.0-alpha.12`

## Verification

- `actionlint .github/workflows/release-unified.yml`
- AutoReview: clean

No release dispatch in this PR.
