### PR TITLE
ci: update release workflow to alpha.13

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.12
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1.0.0-alpha.13
     with:
       version: ${{ inputs.version }}
       repository-type: personal


### PR DESCRIPTION
## Summary

- pin the unified release caller to release-workflows v1.0.0-alpha.13
- retain the existing personal signing contract

## Proof

- actionlint
- AutoReview clean
