### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ## Unreleased
 
+### Documentation
+
+- Reworked the README around installation, first controls, configuration, structured output, and linked reference material.
+
 ## 0.2.1 - 2026-07-17
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -1,88 +1,98 @@
-# 🛏️ eightctl — Control your sleep, from the terminal
+# eightctl 🛏️ — Control your sleep, from the terminal
 
-A modern Go CLI for Eight Sleep Pods. Control power/temperature, alarms, schedules, audio, base, autopilot, travel, household, and export sleep metrics. Includes a daemon for scheduled routines.
+[![CI](https://img.shields.io/github/actions/workflow/status/steipete/eightctl/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/steipete/eightctl/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/steipete/eightctl?style=flat-square)](https://github.com/steipete/eightctl/releases/latest)
+[![Go](https://img.shields.io/github/go-mod/go-version/steipete/eightctl?style=flat-square)](https://go.dev/)
+[![License](https://img.shields.io/github/license/steipete/eightctl?style=flat-square)](LICENSE)
+[![Homebrew](https://img.shields.io/badge/Homebrew-steipete%2Ftap-orange?style=flat-square)](https://github.com/steipete/homebrew-tap)
 
-> Eight Sleep does **not** publish a stable public API. `eightctl` talks to the same undocumented cloud endpoints the mobile apps use. Default OAuth client creds are baked in (from Android APK 7.39.17), so typically you only supply email + password.
-> **Status:** WIP. The code paths are implemented, but live verification is currently blocked by Eight Sleep API rate limiting on the test account.
+`eightctl` is an unofficial CLI for controlling Eight Sleep Pods and exporting sleep data. It is for people who want pod controls and metrics from a terminal or script.
 
-## Quickstart
-```bash
-# build + install
-GO111MODULE=on go install github.com/steipete/eightctl/cmd/eightctl@latest
+> [!IMPORTANT]
+> Eight Sleep does not publish a stable public API. `eightctl` uses the company's cloud endpoints, so provider changes and rate limits can interrupt commands; it does not provide local or Bluetooth control.
 
-# create config (optional; flags/env also work)
-mkdir -p ~/.config/eightctl
-cat > ~/.config/eightctl/config.yaml <<'CFG'
-email: "you@example.com"
-password: "your-password"
-# user_id: "optional"               # auto-resolved via /users/me
-# timezone: "America/New_York"      # defaults to local
-# client_id / client_secret optional # defaults to app creds
-CFG
-chmod 600 ~/.config/eightctl/config.yaml
+## Install
 
-# check pod state
-EIGHTCTL_EMAIL=you@example.com EIGHTCTL_PASSWORD=your-password eightctl status
+With [Homebrew](https://brew.sh/):
 
-# set temperature level (-100..100); without --side, applies to all discovered sides/users
-eightctl temp 20
-
-# target a specific side when the household is split
-eightctl temp -40 --side right
-eightctl on --side left
-
-# run daemon with your YAML schedule (see docs/example-schedule.yaml)
-eightctl daemon --dry-run
+```sh
+brew install steipete/tap/eightctl
 ```
 
-## Command Surface
-- **Power & temp:** `on`, `off`, `temp <level>`, `status`
-- **Away mode:** `away on|off`
-- **Schedules & daemon:** `schedule list` (Autopilot/smart schedule), `daemon`
-- **Alarms:** `alarm list|create|update|delete|snooze|dismiss|dismiss-all|vibration-test`
-- **Temperature modes:** `tempmode nap on|off|extend|status`, `tempmode hotflash on|off|status`, `tempmode events`
-- **Audio:** `audio tracks|categories|state|play|pause|seek|volume|pair|next`, `audio favorites list|add|remove`
-- **Base:** `base info|angle|presets|preset-run|test`
-- **Device:** `device info|peripherals|owner|warranty|online|priming-tasks|priming-schedule`
-- **Metrics:** `sleep day|range`, `presence [--from --to]`, `metrics trends|intervals`
-- **Autopilot:** `autopilot details|history|recap`, `autopilot level-suggestions`, `autopilot snore-mitigation`
-- **Travel:** `travel trips|create-trip|delete-trip|plans|create-plan|update-plan|tasks|airport-search|flight-status`
-- **Household:** `household summary|schedule|current-set|invitations|devices|users|guests`
-- **Misc:** `tracks`, `feats`, `whoami`, `logout`, `version`
+Prebuilt archives for macOS, Linux, and Windows on amd64 and arm64 are available from the [latest GitHub release](https://github.com/steipete/eightctl/releases/latest).
 
-Use `--output table|json|csv` and `--fields field1,field2` to shape output. `--verbose` enables debug logs; `--quiet` hides the config banner.
+To build and install from source, use Go 1.26.5 or newer:
 
-## Household Targeting
-- `status` shows discovered household targets by default when available, including `left` / `right` or inferred `solo`.
-- `on`, `off`, and `temp` apply to all discovered household targets by default.
-- Use `--side left|right|solo` to target one household side.
-- Use `--target-user-id <id>` when you want to address a specific discovered user directly.
-- For split households, `eightctl status --output json` is the quickest way to inspect available sides and user IDs.
+```sh
+go install github.com/steipete/eightctl/cmd/eightctl@latest
+```
+
+## Quick start
+
+Set your Eight Sleep account credentials, then inspect and control the pod:
+
+```sh
+export EIGHTCTL_EMAIL="you@example.com"
+export EIGHTCTL_PASSWORD="your-password"
+
+eightctl status
+eightctl temp 20
+eightctl temp -40 --side right
+```
+
+`status`, `on`, `off`, and `temp` act on all discovered household sides unless you select one with `--side left|right|solo` or `--target-user-id <id>`.
+
+## Commands
+
+| Area | Commands |
+| --- | --- |
+| Pod control | `status`, `on`, `off`, `temp`, `away` |
+| Sleep data | `sleep`, `presence`, `metrics` |
+| Pod features | `alarm`, `audio`, `base`, `device`, `schedule`, `tempmode` |
+| Account and travel | `household`, `autopilot`, `travel` |
+
+Run `eightctl <command> --help` for flags and subcommands. The [command specification](docs/spec.md#cli-surface-implemented) covers the complete surface and current provider constraints.
 
 ## Configuration
-Priority: flags > env vars (`EIGHTCTL_*`) > config file.
 
-Key fields: `email`, `password`, optional `user_id`, `client_id`, `client_secret`, `timezone`, `output`, `fields`, `verbose`. The client auto-resolves `user_id` and `device_id` after authentication. Config file permissions are checked (warn if >0600).
+Flags take precedence over `EIGHTCTL_*` environment variables, which take precedence over `~/.config/eightctl/config.yaml`:
 
-## Tooling
-- Go: module targets Go 1.26.5 and lets `actions/setup-go` read `go.mod`.
-- Make: `make fmt` (tracked `go tool` gofumpt), `make lint` (golangci-lint), `make test`, `make coverage`.
-- Coverage: CI enforces >=85% on core packages (`internal/client`, `config`, `daemon`, `output`, `tokencache`); command wiring still runs through `go test ./...`.
-- CI: `.github/workflows/ci.yml` runs format, lint, tests, the coverage gate, and a release-artifact version smoke test.
-- Releases: the manual `Release (unified)` workflow freezes a protected green `main`, creates the `v*` tag, publishes signed and notarized macOS binaries plus the GoReleaser matrix, and uses the matching changelog section for notes. `Release (legacy manual)` remains an explicit fallback for existing tags and never runs automatically.
-- pnpm scripts (optional): `pnpm eightctl|start|build|lint|format|test|coverage` (see package.json).
+```yaml
+email: "you@example.com"
+password: "your-password"
+timezone: "America/New_York"
+output: "table"
+```
 
-## Known API realities
-- The API is undocumented and rate-limited; repeated logins can return 429. The client now mimics Android app headers and reuses tokens to reduce throttling, but cooldowns may still apply.
-- Authentication uses the OAuth2 password grant against `auth-api.8slp.net/v1/tokens` with `application/x-www-form-urlencoded` bodies. The legacy `/login` JSON endpoint is no longer called.
-- HTTPS only; no local/Bluetooth control exposed here.
-- Eight Sleep retired the temperature-schedules/routines CRUD API; `schedule list` now surfaces the Autopilot (smart) schedule from the `smart` subfield of `app-api.8slp.net/v1/users/:id/temperature`. `metrics summary`, `metrics aggregate`, and `metrics insights` were removed because the underlying endpoints no longer exist — use `metrics trends` instead.
-- The `tz` query param rejects the literal strings `local` / `Local`. The client resolves `--timezone local` (the default) to a real IANA zone, falling back to `UTC` with a warning when the system has no zoneinfo.
+Keep the file readable only by your account with `chmod 600 ~/.config/eightctl/config.yaml`. The optional `user_id` is resolved after authentication, and the public app OAuth client is used unless `client_id` and `client_secret` are set.
 
-## Prior Work / References
-- Go CLI `clim8`: https://github.com/blacktop/clim8
-- MCP server (Node/TS): https://github.com/elizabethtrykin/8sleep-mcp
-- Python library `pyEight`: https://github.com/mezz64/pyEight
-- Home Assistant integrations: https://github.com/lukas-clarke/eight_sleep and https://github.com/grantnedwards/eight-sleep
-- Homebridge plugin: https://github.com/nfarina/homebridge-eightsleep
-- Background on the unofficial API and feature removals: https://www.reddit.com/r/EightSleep/comments/15ybfrv/eight_sleep_removed_smart_home_capabilities/
+## Structured output
+
+Commands that return rows support table, JSON, and CSV output. Use `--fields` to select columns:
+
+```sh
+eightctl status --output json
+eightctl sleep day --date 2026-08-01 --output csv
+eightctl status --fields side,name,mode,level
+```
+
+## Authentication and API behavior
+
+`eightctl` authenticates against Eight Sleep's OAuth service and caches tokens in the operating system keyring, with a file-backed fallback. Reusing cached tokens reduces login traffic, but the provider can still return rate-limit errors.
+
+The API is undocumented and cloud-only. The [project specification](docs/spec.md#reality-of-the-api) records the current contract, while [CHANGELOG.md](CHANGELOG.md) tracks endpoint removals and compatibility changes.
+
+## Development
+
+```sh
+go build ./cmd/eightctl
+go test ./...
+make coverage
+make lint
+```
+
+CI runs formatting, lint, tests, the core-package coverage gate, and a release-artifact smoke test.
+
+## License
+
+MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrites the README from 88 to 98 lines around the house-standard path: pitch, dynamic badges, real install channels, quick start, progressive command/configuration depth, development, and license.
- Uses the actual `ci.yml` workflow, dynamic release/Go/license badges, the existing Homebrew formula, published GitHub release archives, and the Go module install path.

## Content routing

- The exhaustive command surface, household targeting details, API contract, and prior-work references remain in `docs/spec.md`; endpoint history remains in `CHANGELOG.md`. No new reference file was needed.
- Drops the old WIP/test-account status because it is not a stable project fact.
- Drops the daemon quickstart because verification found it currently cannot load a configuration file: `eightctl --config <file> daemon --dry-run` returns `no config file loaded; specify --config`. The config package reads through a separate Viper instance while the daemon checks the global `viper.ConfigFileUsed()` value. This PR does not change code.
- Does not list npm because `eightctl` is unpublished there.

## Verification

- `go build ./cmd/eightctl` — passed.
- `go test ./...` — passed.
- `make coverage` — passed at 85.1% core coverage.
- `make lint` — passed with 0 issues.
- `brew fetch --formula steipete/tap/eightctl` — fetched the existing formula.
- `GOBIN=<scratch> go install github.com/steipete/eightctl/cmd/eightctl@latest` — installed published module v0.2.1; the binary ran `version` successfully.
- Root, `status`, `temp`, and `sleep day` help output validated the quickstart and structured-output flags. Live control/data commands require an Eight Sleep account and pod, so they were validated against real `--help` output rather than sent to the provider.
- The YAML configuration sample loaded successfully through the built binary; the daemon failure above was reproduced separately.
- Every relative link resolves. Every external README URL returned HTTP 200. All five shields badges returned HTTP 200 and none rendered an invalid/not-found card.
- `autoreview --mode local` — clean; no accepted/actionable findings.
