### PR TITLE
fix: honor daemon config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `daemon --config` discovery so scheduled routines use the configuration file selected on the command line.
+
 ### Documentation
 
 - Reworked the README around installation, first controls, configuration, structured output, and linked reference material.

--- a/README.md
+++ b/README.md
@@ -62,9 +62,19 @@ email: "you@example.com"
 password: "your-password"
 timezone: "America/New_York"
 output: "table"
+schedule:
+  - time: "22:30"
+    action: "temp"
+    temperature: "-20"
 ```
 
 Keep the file readable only by your account with `chmod 600 ~/.config/eightctl/config.yaml`. The optional `user_id` is resolved after authentication, and the public app OAuth client is used unless `client_id` and `client_secret` are set.
+
+Preview scheduled actions without changing the pod, then remove `--dry-run` when the schedule is ready:
+
+```sh
+eightctl daemon --config ~/.config/eightctl/config.yaml --dry-run
+```
 
 ## Structured output
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -80,6 +80,7 @@ Audio/temperature data helpers:
 ## Daemon Behavior
 - Reads YAML schedule (time, action on|off|temp, temperature with unit), minute tick, executes once per day, PID guard, SIGINT/SIGTERM graceful stop.
 - Optional state sync compares expected schedule state vs device and reconciles.
+- Start with `eightctl daemon --config ~/.config/eightctl/config.yaml --dry-run` to validate scheduled actions without changing the pod.
 
 ## Testing & Quality Gates
 - `go test ./...` (fast compile checks) — run before handoff.

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -61,6 +61,55 @@ func TestReadConfigSchedule(t *testing.T) {
 	}
 }
 
+func TestDaemonConfigFlagUsesLoadedFile(t *testing.T) {
+	resetViper(t)
+	path := filepath.Join(t.TempDir(), "daemon.yaml")
+	data := strings.Join([]string{
+		"email: test@example.com",
+		"password: test-password",
+		"schedule:",
+		"  - time: \"07:30\"",
+		"    action: temp",
+		"    temperature: -20",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	configFlag := rootCmd.PersistentFlags().Lookup("config")
+	originalValue := configFlag.Value.String()
+	originalChanged := configFlag.Changed
+	t.Cleanup(func() {
+		_ = configFlag.Value.Set(originalValue)
+		configFlag.Changed = originalChanged
+		viper.Reset()
+	})
+	if err := configFlag.Value.Set(path); err != nil {
+		t.Fatalf("set --config: %v", err)
+	}
+	configFlag.Changed = true
+	if err := viper.BindPFlag("config", configFlag); err != nil {
+		t.Fatalf("bind --config: %v", err)
+	}
+
+	initConfig()
+	if got := viper.ConfigFileUsed(); got != path {
+		t.Fatalf("ConfigFileUsed = %q, want %q", got, path)
+	}
+	loaded, err := readConfigSchedule()
+	if err != nil {
+		t.Fatalf("readConfigSchedule: %v", err)
+	}
+	items, err := parseSchedule(loaded)
+	if err != nil {
+		t.Fatalf("parseSchedule: %v", err)
+	}
+	want := []daemon.ScheduleItem{{Time: "07:30", Action: "temp", Temperature: "-20"}}
+	if !reflect.DeepEqual(items, want) {
+		t.Fatalf("schedule = %#v, want %#v", items, want)
+	}
+}
+
 func TestDefaultPIDFile(t *testing.T) {
 	if got := defaultPIDFile("/tmp/custom.pid"); got != "/tmp/custom.pid" {
 		t.Fatalf("defaultPIDFile explicit = %q", got)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -82,7 +82,7 @@ func init() {
 }
 
 func initConfig() {
-	cfg, err := config.Load(viper.GetString("config"), viper.GetBool("config-quiet"))
+	cfg, err := config.Load(viper.GetViper(), viper.GetString("config"), viper.GetBool("config-quiet"))
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,10 +22,8 @@ type Config struct {
 	Verbose      bool     `mapstructure:"verbose"`
 }
 
-// Load initializes viper and unmarshals Config.
-func Load(configPath string, quiet bool) (Config, error) {
-	v := viper.New()
-
+// Load configures v, reads the selected file, and unmarshals Config.
+func Load(v *viper.Viper, configPath string, quiet bool) (Config, error) {
 	v.SetConfigType("yaml")
 	v.SetEnvPrefix("EIGHTCTL")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func TestLoadReadsConfigAndEnv(t *testing.T) {
@@ -24,7 +26,7 @@ func TestLoadReadsConfigAndEnv(t *testing.T) {
 	}
 	t.Setenv("EIGHTCTL_PASSWORD", "env-pass")
 
-	got, err := Load(cfgPath, true)
+	got, err := Load(viper.New(), cfgPath, true)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
@@ -44,7 +46,7 @@ func TestLoadReadsConfigAndEnv(t *testing.T) {
 
 func TestLoadDefaultsWhenConfigMissing(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	got, err := Load("", true)
+	got, err := Load(viper.New(), "", true)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}


### PR DESCRIPTION
## Summary

- load configuration into the same Viper instance used by Cobra commands
- cover an explicit daemon config flag through schedule parsing
- restore the daemon dry-run quickstart and document the fix

## Root cause

The config package created a private Viper instance. It decoded credentials and settings from the selected file, but the daemon later queried the package-global Viper for the loaded file path. As a result, a valid explicit config loaded successfully and was still reported as missing.

## Verification

- manual daemon dry run reached `daemon started with 1 items` using an explicit valid YAML file
- `go test ./...`
- `make coverage` (85.1% core coverage)
- `make lint` (0 issues)
- `go build ./cmd/eightctl`
- autoreview clean with no accepted or actionable findings

Follow-up to #60.
