### PR TITLE
chore(release): sync v0.2.2 metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eightctl",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "Go CLI for Eight Sleep Pods, with pnpm scripts for convenience",
   "engines": {


### PR DESCRIPTION
## Summary

- Synchronize the private package metadata with the 0.2.2 release version.

## Context

Unified release run 30780420500 stopped before tag creation because the frozen-source validator requires package.json to match the requested release version.

## Verification

- Full local CI-equivalent gate
- 85.1% core coverage
- GoReleaser snapshot version smoke test
- Codex autoreview: clean
