### PR TITLE
chore: open next Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier project history from git.
 
+## Unreleased
+
 ## 0.2.2 - 2026-08-02
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Open the next Unreleased changelog section after the verified 0.2.2 release.

## Verification

- Generated 0.2.2 release notes still match the published GitHub Release body.
- Codex autoreview: clean.
