### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ### Release engineering
 
+- Raised the minimum Go version to 1.26.6 for the latest standard-library security fixes.
 - Made release retries verify and reuse an already-published release, added release metadata consistency checks, and moved Go dependency-graph submission into a repository-owned workflow.
 
 ## 0.2.2 - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ brew install steipete/tap/eightctl
 
 Prebuilt archives for macOS, Linux, and Windows on amd64 and arm64 are available from the [latest GitHub release](https://github.com/steipete/eightctl/releases/latest).
 
-To build and install from source, use Go 1.26.5 or newer:
+To build and install from source, use Go 1.26.6 or newer:
 
 ```sh
 go install github.com/steipete/eightctl/cmd/eightctl@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/eightctl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/99designs/keyring v1.2.2


### PR DESCRIPTION
## Summary

- raise the module and documented Go floor to 1.26.6
- record the security-floor update in the changelog
- clear GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218

## Verification

- `GOTOOLCHAIN=go1.26.6 go build ./...`
- `GOTOOLCHAIN=go1.26.6 go test ./...`
- `GOTOOLCHAIN=go1.26.6 go vet ./...`
- built the CLI and ran `eightctl version` plus `eightctl --help`
- autoreview clean
