### PR TITLE
chore(release): fix changelog section for v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier project history from git.
 
-## v0.2.3 - 2026-08-14
+## 0.2.3 - 2026-08-14
 
 ### Release engineering
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eightctl",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Go CLI for Eight Sleep Pods, with pnpm scripts for convenience",
   "engines": {


### PR DESCRIPTION
Release validator requires exactly one dated level-two section matching the repo's header convention.