### PR TITLE
feat: add one-off alarm creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ eightctl temp -40 --side right
 
 `status`, `on`, `off`, and `temp` act on all discovered household sides unless you select one with `--side left|right|solo` or `--target-user-id <id>`.
 
+Create a one-time vibration alarm, optionally with thermal wake:
+
+```sh
+eightctl alarm create-one-off --time 08:30 --thermal-level -10
+```
+
 ## Commands
 
 | Area | Commands |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -27,8 +27,11 @@ Schedules & daemon:
 - `daemon` (YAML-based scheduler with PID guard, dry-run, timezone override, optional state sync)
 
 Alarms:
-- `alarm list|create|update|delete`
+- `alarm list|create|create-one-off|update|delete`
 - `alarm snooze|dismiss|dismiss-all|vibration-test`
+- `alarm create-one-off` accepts `--time`, optional thermal wake with
+  `--thermal-level`, and vibration settings with `--vibration-level` and
+  `--pattern`.
 
 Temperature modes & events:
 - `tempmode nap on|off|extend|status`

--- a/internal/client/action_endpoints_test.go
+++ b/internal/client/action_endpoints_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -369,4 +370,59 @@ func TestClientCoreActionEndpoints(t *testing.T) {
 		},
 	}
 	assertActionEndpoints(t, tests)
+}
+
+func TestCreateOneOffAlarmReturnsNestedResponse(t *testing.T) {
+	c, _, cleanup := newRecordingClient(t)
+	defer cleanup()
+
+	got, err := c.CreateOneOffAlarm(context.Background(), OneOffAlarm{
+		Time:    "08:30:00",
+		Enabled: true,
+		Vibration: AlarmVibration{
+			Enabled:    true,
+			PowerLevel: 50,
+			Pattern:    "RISE",
+		},
+		Thermal: AlarmThermal{Enabled: true, Level: -10},
+	})
+	if err != nil {
+		t.Fatalf("CreateOneOffAlarm: %v", err)
+	}
+	if got.ID != "one-off-alarm" || got.Time != "08:30:00" {
+		t.Fatalf("alarm = %#v, want returned ID and time", got)
+	}
+	if got.Thermal.Level != -10 || !got.Thermal.Enabled {
+		t.Fatalf("thermal = %#v, want enabled level -10", got.Thermal)
+	}
+}
+
+func TestCreateOneOffAlarmPayload(t *testing.T) {
+	c, records, cleanup := newRecordingClient(t)
+	defer cleanup()
+
+	_, err := c.CreateOneOffAlarm(context.Background(), OneOffAlarm{
+		Time:    "08:30:00",
+		Enabled: true,
+		Vibration: AlarmVibration{
+			Enabled:    true,
+			PowerLevel: 50,
+			Pattern:    "RISE",
+		},
+		Thermal: AlarmThermal{Enabled: true, Level: -10},
+	})
+	if err != nil {
+		t.Fatalf("CreateOneOffAlarm: %v", err)
+	}
+
+	body := (*records)[0].Body
+	for _, want := range []string{
+		`"time":"08:30:00"`,
+		`"vibration":{"enabled":true,"powerLevel":50,"pattern":"RISE"}`,
+		`"thermal":{"enabled":true,"level":-10}`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body = %q, missing %q", body, want)
+		}
+	}
 }

--- a/internal/client/action_endpoints_test.go
+++ b/internal/client/action_endpoints_test.go
@@ -26,6 +26,27 @@ func TestClientCoreActionEndpoints(t *testing.T) {
 			bodyHas: `"time":"07:00"`,
 		},
 		{
+			name: "CreateOneOffAlarm",
+			call: func(ctx context.Context, c *Client) error {
+				_, err := c.CreateOneOffAlarm(ctx, OneOffAlarm{
+					Time:    "08:30:00",
+					Enabled: true,
+					Vibration: AlarmVibration{
+						Enabled:    true,
+						PowerLevel: 50,
+						Pattern:    "RISE",
+					},
+					Thermal: AlarmThermal{
+						Enabled: true,
+						Level:   -10,
+					},
+				})
+				return err
+			},
+			want:    recordedRequest{Method: http.MethodPost, Path: "/v1/users/uid/alarms"},
+			bodyHas: `"thermal":{"enabled":true,"level":-10}`,
+		},
+		{
 			name: "UpdateAlarm",
 			call: func(ctx context.Context, c *Client) error {
 				_, err := c.UpdateAlarm(ctx, "alarm-1", map[string]any{"enabled": false})

--- a/internal/client/actions_test.go
+++ b/internal/client/actions_test.go
@@ -62,6 +62,8 @@ func writeActionResponse(t *testing.T, w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/users/uid/alarms" && r.Method == http.MethodGet:
 		io.WriteString(w, `{"alarms":[{"id":"alarm-1","time":"07:00","enabled":true,"daysOfWeek":[1],"vibration":true}]}`)
+	case r.URL.Path == "/v1/users/uid/alarms" && r.Method == http.MethodPost:
+		io.WriteString(w, `{"alarm":{"id":"one-off-alarm","time":"08:30:00","enabled":true,"vibration":{"enabled":true,"powerLevel":50,"pattern":"RISE"},"thermal":{"enabled":true,"level":-10}}}`)
 	case strings.HasPrefix(r.URL.Path, "/users/uid/alarms") && (r.Method == http.MethodPost || r.Method == http.MethodPatch):
 		io.WriteString(w, `{"alarm":{"id":"alarm-1","time":"07:00","enabled":true}}`)
 	case r.URL.Path == "/users/uid/audio/tracks" || r.URL.Path == "/audio/tracks":

--- a/internal/client/alarmlist.go
+++ b/internal/client/alarmlist.go
@@ -16,6 +16,29 @@ type Alarm struct {
 	Sound      *string `json:"sound,omitempty"`
 }
 
+// AlarmVibration describes the vibration wake component of a one-off alarm.
+type AlarmVibration struct {
+	Enabled    bool   `json:"enabled"`
+	PowerLevel int    `json:"powerLevel"`
+	Pattern    string `json:"pattern"`
+}
+
+// AlarmThermal describes the thermal wake component of a one-off alarm.
+type AlarmThermal struct {
+	Enabled bool `json:"enabled"`
+	Level   int  `json:"level"`
+}
+
+// OneOffAlarm is the current app-API payload for a single-use alarm.
+type OneOffAlarm struct {
+	ID            string         `json:"id,omitempty"`
+	Enabled       bool           `json:"enabled"`
+	Time          string         `json:"time"`
+	NextTimestamp string         `json:"nextTimestamp,omitempty"`
+	Vibration     AlarmVibration `json:"vibration"`
+	Thermal       AlarmThermal   `json:"thermal"`
+}
+
 func (c *Client) ListAlarms(ctx context.Context) ([]Alarm, error) {
 	if err := c.requireUser(ctx); err != nil {
 		return nil, err
@@ -39,6 +62,23 @@ func (c *Client) CreateAlarm(ctx context.Context, alarm Alarm) (*Alarm, error) {
 		Alarm Alarm `json:"alarm"`
 	}
 	if err := c.do(ctx, http.MethodPost, path, nil, alarm, &res); err != nil {
+		return nil, err
+	}
+	return &res.Alarm, nil
+}
+
+// CreateOneOffAlarm creates a single-use alarm through the current app API.
+// Unlike the recurring alarm endpoint, this payload has no weekday repeat
+// configuration and uses nested vibration and thermal wake settings.
+func (c *Client) CreateOneOffAlarm(ctx context.Context, alarm OneOffAlarm) (*OneOffAlarm, error) {
+	if err := c.requireUser(ctx); err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/v1/users/%s/alarms", c.UserID)
+	var res struct {
+		Alarm OneOffAlarm `json:"alarm"`
+	}
+	if err := c.doApp(ctx, http.MethodPost, path, nil, alarm, &res); err != nil {
 		return nil, err
 	}
 	return &res.Alarm, nil

--- a/internal/cmd/alarm.go
+++ b/internal/cmd/alarm.go
@@ -98,11 +98,11 @@ var alarmCreateOneOffCmd = &cobra.Command{
 		if vibrationLevel != 20 && vibrationLevel != 50 && vibrationLevel != 100 {
 			return fmt.Errorf("--vibration-level must be 20, 50, or 100")
 		}
-		pattern := strings.ToUpper(viper.GetString("one-off-pattern"))
-		if pattern != "RISE" && pattern != "INTENSE" {
-			return fmt.Errorf("--pattern must be RISE or INTENSE")
+		pattern, err := normalizeOneOffPattern(viper.GetString("one-off-pattern"))
+		if err != nil {
+			return err
 		}
-		thermalEnabled := cmd.Flags().Changed("thermal-level") && !viper.GetBool("one-off-no-thermal")
+		thermalEnabled := oneOffThermalLevelProvided(cmd) && !viper.GetBool("one-off-no-thermal")
 		thermalLevel := viper.GetInt("one-off-thermal-level")
 		if thermalEnabled && (thermalLevel < -100 || thermalLevel > 100) {
 			return fmt.Errorf("--thermal-level must be between -100 and 100")
@@ -132,6 +132,21 @@ var alarmCreateOneOffCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func normalizeOneOffPattern(value string) (string, error) {
+	switch strings.ToUpper(value) {
+	case "RISE":
+		return "RISE", nil
+	case "INTENSE":
+		return "intense", nil
+	default:
+		return "", fmt.Errorf("--pattern must be RISE or INTENSE")
+	}
+}
+
+func oneOffThermalLevelProvided(cmd *cobra.Command) bool {
+	return cmd.Flags().Changed("thermal-level") || viper.IsSet("one-off-thermal-level")
 }
 
 func normalizeAlarmTime(value string) (string, error) {

--- a/internal/cmd/alarm.go
+++ b/internal/cmd/alarm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -82,6 +83,67 @@ var alarmCreateCmd = &cobra.Command{
 	},
 }
 
+var alarmCreateOneOffCmd = &cobra.Command{
+	Use:   "create-one-off",
+	Short: "Create a single-use alarm",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAuthFields(); err != nil {
+			return err
+		}
+		timeStr, err := normalizeAlarmTime(viper.GetString("one-off-time"))
+		if err != nil {
+			return err
+		}
+		vibrationLevel := viper.GetInt("one-off-vibration-level")
+		if vibrationLevel != 20 && vibrationLevel != 50 && vibrationLevel != 100 {
+			return fmt.Errorf("--vibration-level must be 20, 50, or 100")
+		}
+		pattern := strings.ToUpper(viper.GetString("one-off-pattern"))
+		if pattern != "RISE" && pattern != "INTENSE" {
+			return fmt.Errorf("--pattern must be RISE or INTENSE")
+		}
+		thermalEnabled := cmd.Flags().Changed("thermal-level") && !viper.GetBool("one-off-no-thermal")
+		thermalLevel := viper.GetInt("one-off-thermal-level")
+		if thermalEnabled && (thermalLevel < -100 || thermalLevel > 100) {
+			return fmt.Errorf("--thermal-level must be between -100 and 100")
+		}
+
+		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
+		res, err := cl.CreateOneOffAlarm(context.Background(), client.OneOffAlarm{
+			Enabled: true,
+			Time:    timeStr,
+			Vibration: client.AlarmVibration{
+				Enabled:    !viper.GetBool("one-off-no-vibration"),
+				PowerLevel: vibrationLevel,
+				Pattern:    pattern,
+			},
+			Thermal: client.AlarmThermal{
+				Enabled: thermalEnabled,
+				Level:   thermalLevel,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		if res.ID != "" {
+			fmt.Printf("created one-off alarm %s for %s\n", res.ID, res.Time)
+		} else {
+			fmt.Printf("created one-off alarm for %s\n", res.Time)
+		}
+		return nil
+	},
+}
+
+func normalizeAlarmTime(value string) (string, error) {
+	for _, layout := range []string{"15:04", "15:04:05"} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed.Format("15:04:05"), nil
+		}
+	}
+	return "", fmt.Errorf("--time must be HH:MM or HH:MM:SS")
+}
+
 var alarmUpdateCmd = &cobra.Command{
 	Use:   "update <id>",
 	Short: "Update an alarm",
@@ -147,6 +209,19 @@ func init() {
 	viper.BindPFlag("no-vibration", alarmCreateCmd.Flags().Lookup("no-vibration"))
 	viper.BindPFlag("sound", alarmCreateCmd.Flags().Lookup("sound"))
 
+	alarmCreateOneOffCmd.Flags().String("time", "", "HH:MM or HH:MM:SS time")
+	alarmCreateOneOffCmd.Flags().Bool("no-vibration", false, "Disable vibration")
+	alarmCreateOneOffCmd.Flags().Int("vibration-level", 50, "Vibration level: 20, 50, or 100")
+	alarmCreateOneOffCmd.Flags().String("pattern", "RISE", "Vibration pattern: RISE or INTENSE")
+	alarmCreateOneOffCmd.Flags().Int("thermal-level", 0, "Thermal wake level (-100..100); enables thermal wake when supplied")
+	alarmCreateOneOffCmd.Flags().Bool("no-thermal", false, "Disable thermal wake")
+	viper.BindPFlag("one-off-time", alarmCreateOneOffCmd.Flags().Lookup("time"))
+	viper.BindPFlag("one-off-no-vibration", alarmCreateOneOffCmd.Flags().Lookup("no-vibration"))
+	viper.BindPFlag("one-off-vibration-level", alarmCreateOneOffCmd.Flags().Lookup("vibration-level"))
+	viper.BindPFlag("one-off-pattern", alarmCreateOneOffCmd.Flags().Lookup("pattern"))
+	viper.BindPFlag("one-off-thermal-level", alarmCreateOneOffCmd.Flags().Lookup("thermal-level"))
+	viper.BindPFlag("one-off-no-thermal", alarmCreateOneOffCmd.Flags().Lookup("no-thermal"))
+
 	alarmUpdateCmd.Flags().String("time", "", "HH:MM time")
 	alarmUpdateCmd.Flags().IntSlice("days", nil, "Comma-separated days 0=Sun..6=Sat")
 	alarmUpdateCmd.Flags().Bool("enabled", true, "Set enabled true/false")
@@ -159,7 +234,7 @@ func init() {
 	viper.BindPFlag("sound", alarmUpdateCmd.Flags().Lookup("sound"))
 
 	// add subcommands
-	alarmCmd.AddCommand(alarmListCmd, alarmCreateCmd, alarmUpdateCmd, alarmDeleteCmd, alarmSnoozeCmd, alarmDismissCmd, alarmDismissAllCmd, alarmVibeCmd)
+	alarmCmd.AddCommand(alarmListCmd, alarmCreateCmd, alarmCreateOneOffCmd, alarmUpdateCmd, alarmDeleteCmd, alarmSnoozeCmd, alarmDismissCmd, alarmDismissAllCmd, alarmVibeCmd)
 }
 
 // snooze

--- a/internal/cmd/alarm_test.go
+++ b/internal/cmd/alarm_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
 
 func TestNormalizeAlarmTime(t *testing.T) {
 	tests := []struct {
@@ -24,5 +28,39 @@ func TestNormalizeAlarmTime(t *testing.T) {
 				t.Fatalf("normalizeAlarmTime(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNormalizeOneOffPattern(t *testing.T) {
+	if got, err := normalizeOneOffPattern("RISE"); err != nil || got != "RISE" {
+		t.Fatalf("RISE = %q, %v", got, err)
+	}
+	if got, err := normalizeOneOffPattern("INTENSE"); err != nil || got != "intense" {
+		t.Fatalf("INTENSE = %q, %v", got, err)
+	}
+	if _, err := normalizeOneOffPattern("unknown"); err == nil {
+		t.Fatal("expected unknown pattern to fail")
+	}
+}
+
+func TestOneOffThermalLevelProvidedFromConfig(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("one-off-thermal-level", -10)
+
+	if !oneOffThermalLevelProvided(alarmCreateOneOffCmd) {
+		t.Fatal("expected configured thermal level to enable thermal wake")
+	}
+}
+
+func TestOneOffThermalLevelNotProvidedByDefault(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	if err := viper.BindPFlag("one-off-thermal-level", alarmCreateOneOffCmd.Flags().Lookup("thermal-level")); err != nil {
+		t.Fatalf("bind thermal level: %v", err)
+	}
+
+	if oneOffThermalLevelProvided(alarmCreateOneOffCmd) {
+		t.Fatal("did not expect the default thermal level to enable thermal wake")
 	}
 }

--- a/internal/cmd/alarm_test.go
+++ b/internal/cmd/alarm_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "testing"
+
+func TestNormalizeAlarmTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "hours and minutes", input: "08:30", want: "08:30:00"},
+		{name: "seconds", input: "08:30:15", want: "08:30:15"},
+		{name: "invalid", input: "tomorrow", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeAlarmTime(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("normalizeAlarmTime(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeAlarmTime(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `alarm create-one-off` for single-use alarms.
- Use the current app API payload with nested vibration and thermal wake settings.
- Validate time, vibration level, pattern, and thermal level inputs.
- Document the command and add request, response, and command tests.

## Why

The existing `alarm create` command requires weekday values and cannot represent a one-time alarm. The current Eight Sleep app API accepts one-off alarms at `POST /v1/users/{userId}/alarms` with nested `vibration` and `thermal` objects and no repeat configuration.

## Verification

- `go test ./...` passed
- `go vet ./...` passed
- gofumpt format check passed
- golangci-lint v2.12.2: 0 issues
- `make coverage`: 85.0% core coverage
- `./scripts/check-release-metadata` passed
