### PR TITLE
fix: trust eightctl in macOS keychain

### DIFF
--- a/internal/tokencache/tokencache.go
+++ b/internal/tokencache/tokencache.go
@@ -57,7 +57,13 @@ func SetOpenFileKeyringForTest(fn func() (keyring.Keyring, error)) (restore func
 
 func defaultOpenKeyring() (keyring.Keyring, error) {
 	home, _ := os.UserHomeDir()
-	return keyring.Open(keyring.Config{
+	config := defaultKeyringConfig()
+	config.FileDir = filepath.Join(home, ".config", "eightctl", "keyring")
+	return keyring.Open(config)
+}
+
+func defaultKeyringConfig() keyring.Config {
+	return keyring.Config{
 		ServiceName: serviceName,
 		AllowedBackends: []keyring.BackendType{
 			keyring.KeychainBackend,
@@ -65,9 +71,9 @@ func defaultOpenKeyring() (keyring.Keyring, error) {
 			keyring.WinCredBackend,
 			keyring.FileBackend,
 		},
-		FileDir:          filepath.Join(home, ".config", "eightctl", "keyring"),
-		FilePasswordFunc: filePassword,
-	})
+		FilePasswordFunc:         filePassword,
+		KeychainTrustApplication: true,
+	}
 }
 
 func defaultOpenFileKeyring() (keyring.Keyring, error) {

--- a/internal/tokencache/tokencache_test.go
+++ b/internal/tokencache/tokencache_test.go
@@ -283,6 +283,13 @@ func TestDefaultOpenFileKeyring(t *testing.T) {
 	}
 }
 
+func TestDefaultKeyringTrustsApplication(t *testing.T) {
+	config := defaultKeyringConfig()
+	if !config.KeychainTrustApplication {
+		t.Fatal("default macOS keychain items should trust the calling application")
+	}
+}
+
 func TestIdentityKeyFromStorageKey(t *testing.T) {
 	id := Identity{BaseURL: "https://api.example.com", ClientID: "client", Email: "user@example.com"}
 	raw, ok := identityKeyFromStorageKey(storageKey(id))


### PR DESCRIPTION
## Summary

- Set `KeychainTrustApplication: true` for the native macOS keychain backend.
- Extract the default keyring configuration so the policy is explicit and testable.
- Add a regression test for the trusted-application setting.

## Why

The previous configuration left the keyring backend with no trusted application access list. macOS could therefore prompt repeatedly while `eightctl` loaded its cached OAuth token.

## Upgrade note

This setting affects newly created or recreated keychain items. Existing items keep their old ACL. After upgrading from an affected build, run `eightctl logout` once and perform one normal authenticated command so the token is recreated under the new policy. That one-time migration step is intentional and avoids deleting or rewriting credentials silently.

Future prompts can still be expected if the token is expired or invalid, the account or environment changes, the binary identity/path changes, or macOS locks or changes the keychain. Normal cached reads from the same trusted build should not prompt.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `make coverage` (85.1%)
- `gofmt` and `git diff --check`