### PR TITLE
feat(away): add away status and fix side mapping while away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ### Highlights
 
-Household-wide away recovery and timezone-correct daemon schedules make travel automation more reliable.
+Away-state readback, reliable household targeting and recovery, and timezone-correct daemon schedules make travel automation easier to check.
 
+- Fixed left/right targeting when one household member is away, and added `away status` to read the cloud-reported state for the household or a selected side/user. Thanks @omarshahine.
 - Fixed `away off --both` reporting success without clearing away mode when all household members are away; fail explicitly when household user IDs cannot be resolved. Thanks @omarshahine.
 - Fixed daemon schedules being missed when the configured timezone and host timezone fall on different dates.
 - Updated to Charm Log 2.0.1 for terminal-aware colors and complete severity labels, go-runewidth 0.0.29 for width fixes, and the maintained YAML v3 parser.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Run `eightctl <command> --help` for flags and subcommands. The [command specific
 
 Use `eightctl away on --both` before a trip and `eightctl away off --both` to resume all household members, including when everyone is already away. If household user IDs cannot be resolved, the command reports an error.
 
+`eightctl away status` reads the cloud-reported state for all discovered household sides; use `--side` or `--target-user-id` to select one person. In contrast, `away on|off` without targeting flags changes only the authenticated user's side. The cloud is eventually consistent: readback may show the previous state after a write and does not immediately confirm that a change took effect.
+
 ## Configuration
 
 Flags take precedence over `EIGHTCTL_*` environment variables, which take precedence over `~/.config/eightctl/config.yaml`:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -20,7 +20,7 @@ Eight Sleep Pod power/control + data-export CLI, written in Go. Targets macOS/Li
 Core: `on`, `off`, `temp <level>`, `status`, `whoami`, `logout`, `version`.
 
 Away mode:
-- `away on|off`
+- `away on|off|status`
 
 Schedules & daemon:
 - `schedule list` (Autopilot smart schedule)
@@ -74,7 +74,9 @@ Audio/temperature data helpers:
 - Logs via charmbracelet/log; `--verbose` for debug; `--quiet` hides config notice.
 - `status` should prefer discovered household targets when available and display `left` / `right` or inferred `solo`.
 - `on`, `off`, and `temp` should default to all discovered household targets unless narrowed with `--side` or `--target-user-id`.
-- `away` should default to the authenticated user's side, accept `--side` or `--target-user-id`, and use `--both` for the household.
+- `away on|off` default to the authenticated user's side, accept `--side` or `--target-user-id`, and use `--both` for the household.
+- `away status` reads all discovered household sides by default, or a selected `--side` / `--target-user-id`; table, JSON, CSV, and `--fields` work as with `status`. `--both` explicitly selects the household and conflicts with a single-target flag.
+- Away readback reports the cloud's state. The cloud is eventually consistent, so status may show the previous state after a write and does not immediately confirm that a change took effect.
 - `temp` accepts negative positional levels such as `temp -40` without requiring `--`.
 
 ## Daemon Behavior

--- a/internal/client/eightsleep.go
+++ b/internal/client/eightsleep.go
@@ -383,6 +383,27 @@ func (c *Client) SetAwayMode(ctx context.Context, userID string, away bool) erro
 	return c.doURL(ctx, http.MethodPut, u, payload, nil)
 }
 
+// GetAwayMode reports whether away mode is currently active for a user.
+// It reads the same app API endpoint SetAwayMode writes to, which answers
+// with {"isAway": bool}. If userID is empty, it defaults to the
+// authenticated user.
+func (c *Client) GetAwayMode(ctx context.Context, userID string) (bool, error) {
+	if userID == "" {
+		if err := c.requireUser(ctx); err != nil {
+			return false, err
+		}
+		userID = c.UserID
+	}
+	var res struct {
+		IsAway bool `json:"isAway"`
+	}
+	u := fmt.Sprintf("%s/users/%s/away-mode", appAPIBaseURL, userID)
+	if err := c.doURL(ctx, http.MethodGet, u, nil, &res); err != nil {
+		return false, err
+	}
+	return res.IsAway, nil
+}
+
 // TempStatus represents current temperature state payload.
 type TempStatus struct {
 	CurrentLevel int `json:"currentLevel"`

--- a/internal/client/eightsleep.go
+++ b/internal/client/eightsleep.go
@@ -395,13 +395,16 @@ func (c *Client) GetAwayMode(ctx context.Context, userID string) (bool, error) {
 		userID = c.UserID
 	}
 	var res struct {
-		IsAway bool `json:"isAway"`
+		IsAway *bool `json:"isAway"`
 	}
 	u := fmt.Sprintf("%s/users/%s/away-mode", appAPIBaseURL, userID)
 	if err := c.doURL(ctx, http.MethodGet, u, nil, &res); err != nil {
 		return false, err
 	}
-	return res.IsAway, nil
+	if res.IsAway == nil {
+		return false, fmt.Errorf("away mode response is missing isAway")
+	}
+	return *res.IsAway, nil
 }
 
 // TempStatus represents current temperature state payload.

--- a/internal/client/eightsleep_test.go
+++ b/internal/client/eightsleep_test.go
@@ -430,3 +430,78 @@ func TestAuthTokenEndpointUsesClientCredentials(t *testing.T) {
 		t.Fatalf("user id = %q, want uid-123", c.UserID)
 	}
 }
+
+func TestGetAwayMode(t *testing.T) {
+	var gotMethod, gotPath string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"user":{"userId":"uid-123","currentDevice":{"id":"dev-1"}}}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"isAway":true}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	old := appAPIBaseURL
+	appAPIBaseURL = srv.URL
+	defer func() { appAPIBaseURL = old }()
+
+	c := New("e", "p", "uid-123", "", "")
+	c.BaseURL = srv.URL
+	c.token = "t"
+	c.tokenExp = time.Now().Add(time.Hour)
+	c.HTTP = srv.Client()
+
+	away, err := c.GetAwayMode(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetAwayMode: %v", err)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotPath != "/users/uid-123/away-mode" {
+		t.Errorf("path = %q, want /users/uid-123/away-mode", gotPath)
+	}
+	if !away {
+		t.Error("away = false, want true")
+	}
+}
+
+func TestGetAwayModeExplicitUser(t *testing.T) {
+	var gotPath string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"isAway":false}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	old := appAPIBaseURL
+	appAPIBaseURL = srv.URL
+	defer func() { appAPIBaseURL = old }()
+
+	c := New("e", "p", "uid-123", "", "")
+	c.BaseURL = srv.URL
+	c.token = "t"
+	c.tokenExp = time.Now().Add(time.Hour)
+	c.HTTP = srv.Client()
+
+	away, err := c.GetAwayMode(context.Background(), "other-uid")
+	if err != nil {
+		t.Fatalf("GetAwayMode: %v", err)
+	}
+	if gotPath != "/users/other-uid/away-mode" {
+		t.Errorf("path = %q, want /users/other-uid/away-mode", gotPath)
+	}
+	if away {
+		t.Error("away = true, want false")
+	}
+}

--- a/internal/client/eightsleep_test.go
+++ b/internal/client/eightsleep_test.go
@@ -505,3 +505,22 @@ func TestGetAwayModeExplicitUser(t *testing.T) {
 		t.Error("away = true, want false")
 	}
 }
+
+func TestGetAwayModeInvalidResponse(t *testing.T) {
+	for _, body := range []string{`{}`, `{"isAway":null}`, `{"isAway":"false"}`} {
+		t.Run(body, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(body))
+			}))
+			defer srv.Close()
+			old := appAPIBaseURL
+			appAPIBaseURL = srv.URL
+			defer func() { appAPIBaseURL = old }()
+			c := New("e", "p", "uid-123", "", "")
+			c.token, c.tokenExp = "t", time.Now().Add(time.Hour)
+			if _, err := c.GetAwayMode(context.Background(), "uid-123"); err == nil {
+				t.Fatal("expected an error for missing or malformed away state")
+			}
+		})
+	}
+}

--- a/internal/client/side_assignments_test.go
+++ b/internal/client/side_assignments_test.go
@@ -1,0 +1,69 @@
+package client
+
+import "testing"
+
+func TestSideAssignmentsFromDevice(t *testing.T) {
+	const userA = "uid-a"
+	const userB = "uid-b"
+
+	tests := []struct {
+		name        string
+		left, right string
+		awaySides   map[string]string
+		want        map[string]string
+	}{
+		{
+			name: "both present",
+			left: userA, right: userB,
+			awaySides: map[string]string{"leftUserId": userA, "rightUserId": userB},
+			want:      map[string]string{userA: "left", userB: "right"},
+		},
+		{
+			// Captured from a live Pod 2 Pro: when the left user goes away,
+			// BOTH top-level slots collapse to the present (right) user while
+			// awaySides retains the true mapping.
+			name: "left user away collapses top-level slots to right user",
+			left: userB, right: userB,
+			awaySides: map[string]string{"leftUserId": userA, "rightUserId": userB},
+			want:      map[string]string{userA: "left", userB: "right"},
+		},
+		{
+			name: "right user away collapses top-level slots to left user",
+			left: userA, right: userA,
+			awaySides: map[string]string{"leftUserId": userA, "rightUserId": userB},
+			want:      map[string]string{userA: "left", userB: "right"},
+		},
+		{
+			name: "genuinely solo household",
+			left: userA, right: userA,
+			awaySides: map[string]string{"leftUserId": userA, "rightUserId": userA},
+			want:      map[string]string{userA: "solo"},
+		},
+		{
+			name: "empty top-level falls back to awaySides",
+			left: "", right: "",
+			awaySides: map[string]string{"leftUserId": userA, "rightUserId": userB},
+			want:      map[string]string{userA: "left", userB: "right"},
+		},
+		{
+			name: "solo with only left populated",
+			left: userA, right: "",
+			awaySides: nil,
+			want:      map[string]string{userA: "solo"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sideAssignmentsFromDevice(tc.left, tc.right, tc.awaySides)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for uid, side := range tc.want {
+				if got[uid] != side {
+					t.Errorf("uid %s: got side %q, want %q (full: %v)", uid, got[uid], side, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/client/targets.go
+++ b/internal/client/targets.go
@@ -96,14 +96,26 @@ func (c *Client) HouseholdUserTargets(ctx context.Context) ([]HouseholdUserTarge
 }
 
 // sideAssignmentsFromDevice builds a userID -> side map from the /devices payload.
-// In Away mode the top-level leftUserId/rightUserId come back empty and the
-// real IDs are stashed inside awaySides as {"leftUserId":"…","rightUserId":"…"}.
+// In Away mode the top-level leftUserId/rightUserId do not come back empty:
+// they both collapse onto whichever user is still present. The real mapping
+// stays in awaySides as {"leftUserId":"…","rightUserId":"…"}.
 func sideAssignmentsFromDevice(leftUserID, rightUserID string, awaySides map[string]string) map[string]string {
-	if leftUserID == "" {
-		leftUserID = awaySides["leftUserId"]
-	}
-	if rightUserID == "" {
-		rightUserID = awaySides["rightUserId"]
+	awayLeft := awaySides["leftUserId"]
+	awayRight := awaySides["rightUserId"]
+
+	// When a user is away the device does not merely blank their slot: both
+	// top-level IDs collapse onto the user who is still present, so the away
+	// user disappears and their partner looks solo. awaySides keeps the true
+	// mapping, so prefer it whenever it names two distinct users.
+	if awayLeft != "" && awayRight != "" && awayLeft != awayRight {
+		leftUserID, rightUserID = awayLeft, awayRight
+	} else {
+		if leftUserID == "" {
+			leftUserID = awayLeft
+		}
+		if rightUserID == "" {
+			rightUserID = awayRight
+		}
 	}
 	out := map[string]string{}
 	switch {

--- a/internal/client/targets.go
+++ b/internal/client/targets.go
@@ -96,17 +96,12 @@ func (c *Client) HouseholdUserTargets(ctx context.Context) ([]HouseholdUserTarge
 }
 
 // sideAssignmentsFromDevice builds a userID -> side map from the /devices payload.
-// In Away mode the top-level leftUserId/rightUserId do not come back empty:
-// they both collapse onto whichever user is still present. The real mapping
-// stays in awaySides as {"leftUserId":"…","rightUserId":"…"}.
+// Away mode can collapse both top-level IDs onto the present user or omit them.
+// Distinct awaySides IDs retain the true left/right mapping.
 func sideAssignmentsFromDevice(leftUserID, rightUserID string, awaySides map[string]string) map[string]string {
 	awayLeft := awaySides["leftUserId"]
 	awayRight := awaySides["rightUserId"]
 
-	// When a user is away the device does not merely blank their slot: both
-	// top-level IDs collapse onto the user who is still present, so the away
-	// user disappears and their partner looks solo. awaySides keeps the true
-	// mapping, so prefer it whenever it names two distinct users.
 	if awayLeft != "" && awayRight != "" && awayLeft != awayRight {
 		leftUserID, rightUserID = awayLeft, awayRight
 	} else {

--- a/internal/cmd/away.go
+++ b/internal/cmd/away.go
@@ -14,7 +14,13 @@ import (
 var awayCmd = &cobra.Command{
 	Use:   "away",
 	Short: "Away mode (vacation)",
-	Long:  "Activate or deactivate away mode. When away, the pod stops heating/cooling.\nTarget a specific side with --side left|right|solo, a specific user with\n--target-user-id, or apply to every household member with --both.\nWith no flags, defaults to the authenticated user's side.\nUse 'away status' to read the current state.",
+	Long: "When away, the pod stops heating/cooling.\n" +
+		"'away on' and 'away off' default to the authenticated user's side;\n" +
+		"use --both to update every household member. 'away status' reports\n" +
+		"all discovered household sides by default. Use --side left|right|solo\n" +
+		"or --target-user-id to select one person for any subcommand.\n" +
+		"The cloud is eventually consistent: status may show the previous state\n" +
+		"after a write and does not immediately confirm that a change took effect.",
 }
 
 var awayOnCmd = &cobra.Command{
@@ -32,52 +38,72 @@ var awayOffCmd = &cobra.Command{
 var awayStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show whether away mode is active",
+	Args:  cobra.NoArgs,
 	Long: "Report away mode for each household side. Narrow to one person with\n" +
-		"--side left|right|solo or --target-user-id.",
+		"--side left|right|solo or --target-user-id. Unlike 'away on' and 'away off',\n" +
+		"this reads all discovered household sides by default.\n" +
+		"The cloud is eventually consistent: status may show the previous state\n" +
+		"after a write and does not immediately confirm that a change took effect.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := requireAuthFields(); err != nil {
 			return err
 		}
 		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
-		ctx := context.Background()
+		return runAwayStatusWithClient(context.Background(), cmd, cl)
+	},
+}
 
-		target, err := resolveSelectedTarget(ctx, cmd, cl)
+func runAwayStatusWithClient(ctx context.Context, cmd *cobra.Command, cl *client.Client) error {
+	both, _ := cmd.Flags().GetBool("both")
+	side, _ := cmd.Flags().GetString("side")
+	userID, _ := cmd.Flags().GetString("target-user-id")
+	if both && (side != "" || userID != "") {
+		return fmt.Errorf("--both conflicts with --side/--target-user-id")
+	}
+	target, err := resolveSelectedTarget(ctx, cmd, cl)
+	if err != nil {
+		return err
+	}
+
+	var targets []client.HouseholdUserTarget
+	if target != nil {
+		targets = []client.HouseholdUserTarget{*target}
+	} else {
+		targets, err = cl.HouseholdUserTargets(ctx)
 		if err != nil {
 			return err
 		}
-
-		var targets []client.HouseholdUserTarget
-		if target != nil {
-			targets = []client.HouseholdUserTarget{*target}
-		} else {
-			targets, err = cl.HouseholdUserTargets(ctx)
-			if err != nil {
-				return err
-			}
+	}
+	if len(targets) == 0 {
+		return fmt.Errorf("no household users found")
+	}
+	for _, current := range targets {
+		if current.UserID == "" {
+			return fmt.Errorf("household user is missing a user ID")
 		}
+	}
 
-		rows := make([]map[string]any, 0, len(targets))
-		for _, current := range targets {
-			away, err := cl.GetAwayMode(ctx, current.UserID)
-			if err != nil {
-				return fmt.Errorf("reading away for %s: %w", current.UserID, err)
-			}
-			rows = append(rows, map[string]any{
-				"side":    current.SideLabel(),
-				"name":    current.DisplayName(),
-				"user_id": current.UserID,
-				"away":    away,
-			})
+	rows := make([]map[string]any, 0, len(targets))
+	for _, current := range targets {
+		away, err := cl.GetAwayMode(ctx, current.UserID)
+		if err != nil {
+			return fmt.Errorf("reading away for %s: %w", current.UserID, err)
 		}
+		rows = append(rows, map[string]any{
+			"side":    current.SideLabel(),
+			"name":    current.DisplayName(),
+			"user_id": current.UserID,
+			"away":    away,
+		})
+	}
 
-		headers := []string{"side", "name", "user_id", "away"}
-		fields := viper.GetStringSlice("fields")
-		rows = output.FilterFields(rows, fields)
-		if len(fields) > 0 {
-			headers = fields
-		}
-		return output.Print(output.Format(viper.GetString("output")), headers, rows)
-	},
+	headers := []string{"side", "name", "user_id", "away"}
+	fields := viper.GetStringSlice("fields")
+	rows = output.FilterFields(rows, fields)
+	if len(fields) > 0 {
+		headers = fields
+	}
+	return output.Print(output.Format(viper.GetString("output")), headers, rows)
 }
 
 func runAway(cmd *cobra.Command, on bool) error {

--- a/internal/cmd/away.go
+++ b/internal/cmd/away.go
@@ -8,12 +8,13 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
+	"github.com/steipete/eightctl/internal/output"
 )
 
 var awayCmd = &cobra.Command{
 	Use:   "away",
 	Short: "Away mode (vacation)",
-	Long:  "Activate or deactivate away mode. When away, the pod stops heating/cooling.\nTarget a specific side with --side left|right|solo, a specific user with\n--target-user-id, or apply to every household member with --both.\nWith no flags, defaults to the authenticated user's side.",
+	Long:  "Activate or deactivate away mode. When away, the pod stops heating/cooling.\nTarget a specific side with --side left|right|solo, a specific user with\n--target-user-id, or apply to every household member with --both.\nWith no flags, defaults to the authenticated user's side.\nUse 'away status' to read the current state.",
 }
 
 var awayOnCmd = &cobra.Command{
@@ -26,6 +27,57 @@ var awayOffCmd = &cobra.Command{
 	Use:   "off",
 	Short: "Deactivate away mode",
 	RunE:  func(cmd *cobra.Command, args []string) error { return runAway(cmd, false) },
+}
+
+var awayStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether away mode is active",
+	Long: "Report away mode for each household side. Narrow to one person with\n" +
+		"--side left|right|solo or --target-user-id.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAuthFields(); err != nil {
+			return err
+		}
+		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
+		ctx := context.Background()
+
+		target, err := resolveSelectedTarget(ctx, cmd, cl)
+		if err != nil {
+			return err
+		}
+
+		var targets []client.HouseholdUserTarget
+		if target != nil {
+			targets = []client.HouseholdUserTarget{*target}
+		} else {
+			targets, err = cl.HouseholdUserTargets(ctx)
+			if err != nil {
+				return err
+			}
+		}
+
+		rows := make([]map[string]any, 0, len(targets))
+		for _, current := range targets {
+			away, err := cl.GetAwayMode(ctx, current.UserID)
+			if err != nil {
+				return fmt.Errorf("reading away for %s: %w", current.UserID, err)
+			}
+			rows = append(rows, map[string]any{
+				"side":    current.SideLabel(),
+				"name":    current.DisplayName(),
+				"user_id": current.UserID,
+				"away":    away,
+			})
+		}
+
+		headers := []string{"side", "name", "user_id", "away"}
+		fields := viper.GetStringSlice("fields")
+		rows = output.FilterFields(rows, fields)
+		if len(fields) > 0 {
+			headers = fields
+		}
+		return output.Print(output.Format(viper.GetString("output")), headers, rows)
+	},
 }
 
 func runAway(cmd *cobra.Command, on bool) error {
@@ -103,6 +155,8 @@ func init() {
 	awayCmd.PersistentFlags().Bool("both", false, "Apply to every household member")
 	addTargetingFlags(awayOnCmd, true)
 	addTargetingFlags(awayOffCmd, true)
+	addTargetingFlags(awayStatusCmd, true)
 	awayCmd.AddCommand(awayOnCmd)
 	awayCmd.AddCommand(awayOffCmd)
+	awayCmd.AddCommand(awayStatusCmd)
 }

--- a/internal/cmd/away_status_test.go
+++ b/internal/cmd/away_status_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/steipete/eightctl/internal/client"
+	"github.com/steipete/eightctl/internal/tokencache"
+)
+
+func TestAwayStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name, device, side, userID, format string
+		fields                             []string
+		both, missingID, failRead          bool
+		wantUsers, wantErr                 string
+	}{
+		{name: "left away collapse", device: `{"leftUserId":"uid-b","rightUserId":"uid-b","awaySides":{"leftUserId":"uid-a","rightUserId":"uid-b"}}`, wantUsers: "uid-b,uid-a"},
+		{name: "right away collapse", device: `{"leftUserId":"uid-a","rightUserId":"uid-a","awaySides":{"leftUserId":"uid-a","rightUserId":"uid-b"}}`, side: "right", wantUsers: "uid-b"},
+		{name: "all away filtered lookup", device: `{"leftUserId":"uid-a","rightUserId":"uid-b"}`, both: true, wantUsers: "uid-a,uid-b"},
+		{name: "explicit user", device: `{"leftUserId":"uid-a","rightUserId":"uid-b"}`, userID: "uid-a", wantUsers: "uid-a"},
+		{name: "fields", device: `{"leftUserId":"uid-a","rightUserId":"uid-b"}`, fields: []string{"side", "away"}, wantUsers: "uid-a,uid-b"},
+		{name: "csv", device: `{"leftUserId":"uid-a","rightUserId":"uid-b"}`, format: "csv", wantUsers: "uid-a,uid-b"},
+		{name: "table", device: `{"leftUserId":"uid-a","rightUserId":"uid-b"}`, format: "table", wantUsers: "uid-a,uid-b"},
+		{name: "empty household", device: `{}`, wantErr: "no household users found"},
+		{name: "missing user ID", device: `{"leftUserId":"uid-a","rightUserId":"uid-b"}`, missingID: true, wantErr: "household user is missing a user ID"},
+		{name: "conflicting side", both: true, side: "left", wantErr: "--both conflicts"},
+		{name: "conflicting user", both: true, userID: "uid-a", wantErr: "--both conflicts"},
+		{name: "read failure", device: `{"leftUserId":"uid-a","rightUserId":"uid-b"}`, failRead: true, wantUsers: "uid-a", wantErr: "reading away for uid-a"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			useTempKeyring(t)
+			resetViper(t)
+			t.Cleanup(viper.Reset)
+			format := tc.format
+			if format == "" {
+				format = "json"
+			}
+			viper.Set("output", format)
+			viper.Set("fields", tc.fields)
+			var readUsers []string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/devices/dev-1", func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("filter") != "leftUserId,rightUserId,awaySides" {
+					t.Error("household discovery omitted the side-field filter")
+					w.Write([]byte(`{"result":{}}`))
+					return
+				}
+				w.Write([]byte(`{"result":` + tc.device + `}`))
+			})
+			mux.HandleFunc("/users/", func(w http.ResponseWriter, r *http.Request) {
+				userID := strings.TrimPrefix(r.URL.Path, "/users/")
+				if tc.missingID && userID == "uid-b" {
+					userID = ""
+				}
+				json.NewEncoder(w).Encode(map[string]any{"user": map[string]any{"userId": userID, "firstName": "User", "currentDevice": map[string]string{"side": "away"}}})
+			})
+			mux.HandleFunc("/v1/users/", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/away-mode") {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				}
+				userID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/users/"), "/away-mode")
+				readUsers = append(readUsers, userID)
+				if tc.failRead {
+					http.Error(w, "fixture failure", http.StatusBadRequest)
+					return
+				}
+				json.NewEncoder(w).Encode(map[string]bool{"isAway": true})
+			})
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+			cl := client.New("fixture@example.invalid", "fixture", "uid-a", "fixture-client", "fixture-secret")
+			cl.BaseURL, cl.DeviceID = srv.URL, "dev-1"
+			if err := tokencache.Save(cl.Identity(), "fixture-token", time.Now().Add(time.Hour), "uid-a"); err != nil {
+				t.Fatal(err)
+			}
+			transport := srv.Client().Transport
+			cl.HTTP = &http.Client{Transport: awayRoundTripper(func(r *http.Request) (*http.Response, error) {
+				if r.URL.Host == "app-api.8slp.net" {
+					r = r.Clone(r.Context())
+					r.URL.Scheme = "http"
+					r.URL.Host = strings.TrimPrefix(srv.URL, "http://")
+				}
+				return transport.RoundTrip(r)
+			})}
+			command := &cobra.Command{}
+			command.Flags().Bool("both", tc.both, "")
+			addTargetingFlags(command, true)
+			command.Flags().Set("side", tc.side)
+			command.Flags().Set("target-user-id", tc.userID)
+			out, err := captureAwayStatus(t, func() error { return runAwayStatusWithClient(context.Background(), command, cl) })
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) || out != "" {
+					t.Fatalf("output %q, error %v; want error %q without output", out, err, tc.wantErr)
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Join(readUsers, ","); got != tc.wantUsers {
+				t.Fatalf("queried users = %q, want %q", got, tc.wantUsers)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if format != "json" {
+				for _, field := range []string{"side", "user_id", "away", "left", "right", "true"} {
+					if !strings.Contains(out, field) {
+						t.Errorf("%s output missing %q: %s", format, field, out)
+					}
+				}
+				return
+			}
+			var rows []map[string]any
+			if err := json.Unmarshal([]byte(out), &rows); err != nil {
+				t.Fatal(err)
+			}
+			if len(rows) != len(readUsers) {
+				t.Fatalf("got %d rows for %d users", len(rows), len(readUsers))
+			}
+			for i, row := range rows {
+				wantSide := map[string]string{"uid-a": "left", "uid-b": "right"}[readUsers[i]]
+				if row["side"] != wantSide || row["away"] != true {
+					t.Errorf("incorrect away row: %+v", row)
+				}
+				if len(tc.fields) > 0 {
+					if len(row) != len(tc.fields) {
+						t.Errorf("unexpected fields: %+v", row)
+					}
+				} else if row["user_id"] != readUsers[i] {
+					t.Errorf("incorrect user: %+v", row)
+				}
+			}
+		})
+	}
+}
+
+func captureAwayStatus(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+	previous := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = previous }()
+	runErr := run()
+	w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out), runErr
+}


### PR DESCRIPTION
## Summary

Adds `away status`, which reports the cloud’s away state for all discovered household sides or a selected `--side` / `--target-user-id`. It supports table, JSON, CSV, and `--fields`. Unlike `away on|off`, readback defaults to the whole household. Help and docs explain that the cloud is eventually consistent: a read can still show the previous state after a write.

Fixes shared side mapping while one household member is away. Both top-level device slots can collapse onto the present user; distinct `awaySides` IDs retain the true left/right assignment. The candidate is rebased onto current main, including #74’s filtered all-away recovery and #78’s maintenance notes. Missing household IDs, absent away-state fields, and conflicting targets now produce errors rather than misleading readback.

## Validation

Full Go 1.26.7 and 1.26.8 suites, client/command race checks, clean lint, 85.5% core coverage, and release metadata/preflight checks pass. The actual release-style Linux CLI passes an isolated OAuth/HTTPS fixture run with networking disabled: both collapsed-side cases, all-away and solo households, side/user selection, table/JSON/CSV output, field filtering, and invalid/error responses. No device writes are sent.

The contributor’s real Pod 2 Pro round-trip trace remains available at https://github.com/steipete/eightctl/pull/73#issuecomment-5473351986. Its older all-away description was corrected during the original investigation; the filtered lookup from #74 is used for current all-away discovery.

A credited Unreleased entry is first under Highlights. Exact-head CI and isolated-review results are recorded in the proof comment.

Co-authored-by: Omar Shahine <10343873+omarshahine@users.noreply.github.com>
