### PR TITLE
build: add make build / make install with the required re-sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,17 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Local install smoke test
+        run: |
+          INSTALL_ROOT=$(mktemp -d)
+          trap 'rm -rf "$INSTALL_ROOT"' EXIT
+          for attempt in 1 2; do
+            GOFLAGS="-ldflags=-X=github.com/steipete/eightctl/internal/cmd.Version=install-proof-$attempt" \
+              make install PREFIX="$INSTALL_ROOT/path with spaces/bin"
+            "$INSTALL_ROOT/path with spaces/bin/eightctl" --help >/dev/null
+            test "$("$INSTALL_ROOT/path with spaces/bin/eightctl" --version)" = "install-proof-$attempt"
+          done
+
       - name: Test minimum supported Go version
         env:
           GOTOOLCHAIN: go1.26.7

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ build:
 # Local development install. NOT the release path -- releases are built by
 # GoReleaser (.goreleaser.yaml) from a tag.
 #
-# The ad-hoc re-sign is required, not hygiene. macOS caches a binary's code
+# The ad-hoc re-sign is required on macOS, not hygiene (it is skipped
+# elsewhere). macOS caches a binary's code
 # signature against its path, so overwriting the file in place leaves the
 # cached CDHash describing content that no longer exists and AMFI SIGKILLs
 # every invocation afterwards. It presents as the binary producing no output
@@ -40,5 +41,10 @@ build:
 # nobody is watching for a dialog.
 install: build
 	install -m 0755 ./eightctl "$(PREFIX)/eightctl"
-	codesign --force --sign - "$(PREFIX)/eightctl"
-	@codesign --verify "$(PREFIX)/eightctl" && echo "installed and signed: $(PREFIX)/eightctl"
+	@if [ "$$(uname -s)" = "Darwin" ]; then \
+		codesign --force --sign - "$(PREFIX)/eightctl" && \
+		codesign --verify "$(PREFIX)/eightctl" && \
+		echo "installed and signed: $(PREFIX)/eightctl"; \
+	else \
+		echo "installed: $(PREFIX)/eightctl"; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: fmt lint test coverage
+# Local install prefix. Override for a different location:
+#   make install PREFIX=/usr/local/bin
+PREFIX ?= /opt/homebrew/bin
+
+.PHONY: fmt lint test coverage build install
 
 fmt:
 	go tool mvdan.cc/gofumpt -w ./
@@ -12,3 +16,29 @@ test:
 coverage:
 	go test -coverpkg=./internal/client,./internal/config,./internal/daemon,./internal/output,./internal/tokencache ./internal/client ./internal/config ./internal/daemon ./internal/output ./internal/tokencache -coverprofile=coverage.out
 	go tool cover -func=coverage.out | awk '/^total:/ {gsub("%", "", $$3); print "core coverage: " $$3 "%"; exit !($$3 >= 85.0)}'
+
+build:
+	go build -o ./eightctl ./cmd/eightctl
+
+# Local development install. NOT the release path -- releases are built by
+# GoReleaser (.goreleaser.yaml) from a tag.
+#
+# The ad-hoc re-sign is required, not hygiene. macOS caches a binary's code
+# signature against its path, so overwriting the file in place leaves the
+# cached CDHash describing content that no longer exists and AMFI SIGKILLs
+# every invocation afterwards. It presents as the binary producing no output
+# at all and exiting 137 -- even `eightctl --help` -- which reads like a
+# hang or a network fault rather than a signing problem. Re-signing
+# refreshes the cache.
+#
+# Expect one more consequence: installing changes the binary's identity, so
+# the cached auth token in the Keychain is still ACL'd to the previous one
+# and the next command blocks on a Keychain prompt. Either answer "Always
+# Allow" once, or run `eightctl logout` -- with credentials in the config
+# file that clears the stale item and the next call re-authenticates with no
+# prompt at all, which is the quicker path on a headless machine where
+# nobody is watching for a dialog.
+install: build
+	install -m 0755 ./eightctl "$(PREFIX)/eightctl"
+	codesign --force --sign - "$(PREFIX)/eightctl"
+	@codesign --verify "$(PREFIX)/eightctl" && echo "installed and signed: $(PREFIX)/eightctl"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-# Local install prefix. Override for a different location:
+# Local binary directory. Override for a different location:
 #   make install PREFIX=/usr/local/bin
-PREFIX ?= /opt/homebrew/bin
+PREFIX ?= $(HOME)/.local/bin
 
 .PHONY: fmt lint test coverage build install
 
@@ -20,26 +20,11 @@ coverage:
 build:
 	go build -o ./eightctl ./cmd/eightctl
 
-# Local development install. NOT the release path -- releases are built by
-# GoReleaser (.goreleaser.yaml) from a tag.
-#
-# The ad-hoc re-sign is required on macOS, not hygiene (it is skipped
-# elsewhere). macOS caches a binary's code
-# signature against its path, so overwriting the file in place leaves the
-# cached CDHash describing content that no longer exists and AMFI SIGKILLs
-# every invocation afterwards. It presents as the binary producing no output
-# at all and exiting 137 -- even `eightctl --help` -- which reads like a
-# hang or a network fault rather than a signing problem. Re-signing
-# refreshes the cache.
-#
-# Expect one more consequence: installing changes the binary's identity, so
-# the cached auth token in the Keychain is still ACL'd to the previous one
-# and the next command blocks on a Keychain prompt. Either answer "Always
-# Allow" once, or run `eightctl logout` -- with credentials in the config
-# file that clears the stale item and the next call re-authenticates with no
-# prompt at all, which is the quicker path on a headless machine where
-# nobody is watching for a dialog.
+# Local development only; release signing is handled by GoReleaser.
+# Re-sign the installed macOS executable so its signature matches its bytes
+# after replacement. This does not preserve existing Keychain authorization.
 install: build
+	install -d "$(PREFIX)"
 	install -m 0755 ./eightctl "$(PREFIX)/eightctl"
 	@if [ "$$(uname -s)" = "Darwin" ]; then \
 		codesign --force --sign - "$(PREFIX)/eightctl" && \

--- a/README.md
+++ b/README.md
@@ -105,11 +105,22 @@ The API is undocumented and cloud-only. The [project specification](docs/spec.md
 The preferred build toolchain is Go 1.26.8, selected by `go.mod`; Go 1.26.7 remains the supported minimum and is tested in CI. The optional package scripts use pnpm 12.3.4 with Node.js 24 or newer.
 
 ```sh
-go build ./cmd/eightctl
+make build
 go test ./...
 make coverage
 make lint
 ```
+
+`make build` writes `./eightctl`. To install a local development build, run
+`make install`; it creates `~/.local/bin` if needed. Add that directory to your
+`PATH`, or select another binary directory with
+`make install PREFIX=/usr/local/bin`.
+
+On macOS, installation ad-hoc signs and verifies the installed executable to
+avoid stale-signature launch failures after replacement. A rebuilt executable
+can still trigger a Keychain authorization prompt when accessing cached tokens;
+this install helper does not make authenticated commands prompt-free on
+unattended hosts. Published releases use the separate signed release pipeline.
 
 CI runs formatting, lint, tests, the core-package coverage gate, and a release-artifact smoke test.
 


### PR DESCRIPTION
Local source updates need an installation path that leaves a runnable macOS executable. This adds `make build` and `make install`, which creates the destination, copies the binary, and ad-hoc signs and verifies it on macOS. Linux skips signing.

`PREFIX` names the binary directory and defaults to `~/.local/bin`; for example, `make install PREFIX=/usr/local/bin`. The README documents local installation and explains that cached-token access can still require Keychain authorization after rebuilding. Credential-storage policy remains separate in #82.

Maintainer finishing retains Omar Shahine's implementation and adds a portable default, destination creation, concise documentation, and a Linux CI smoke test that installs two different builds into a path containing spaces and checks each installed version.

Validation: the full Go 1.26.8 suite passes; core coverage is 85.5%. On macOS arm64, two real builds with distinct embedded versions were installed successively into an initially absent path containing spaces; both `--help` and `--version` succeeded, mode was 0755, and `codesign --verify --strict` passed. CI and final independent review results are recorded in the proof comment.

The changelog credit is collected in the final release-notes PR so this PR remains independent of other prepared changes.
