### PR TITLE
chore(release): prepare v0.2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,4 @@ jobs:
           EXPECTED=$(jq -r '.version' dist/metadata.json)
           ACTUAL=$("$BINARY" version)
           test "$ACTUAL" = "$EXPECTED"
+          test "$("$BINARY" --version)" = "$EXPECTED"

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -46,12 +46,9 @@ jobs:
     with:
       version: ${{ inputs.version }}
       repository-type: personal
-      homebrew-tap: steipete/homebrew-tap
-      homebrew-formula: eightctl
     secrets:
       MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGN_P12 }}
       MACOS_SIGNING_P12_PASSWORD: ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
       ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY }}
-      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -46,9 +46,12 @@ jobs:
     with:
       version: ${{ inputs.version }}
       repository-type: personal
+      homebrew-tap: steipete/homebrew-tap
+      homebrew-formula: eightctl
     secrets:
       MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGN_P12 }}
       MACOS_SIGNING_P12_PASSWORD: ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
       ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
       ASC_PRIVATE_KEY_P8: ${{ secrets.ASC_PRIVATE_KEY }}
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier project history from git.
 
-## Unreleased
+## 0.2.4 - 2026-09-05
 
 ### Highlights
 
@@ -13,6 +13,8 @@ Away-state readback, reliable household targeting and recovery, and timezone-cor
 - Fixed left/right targeting when one household member is away, and added `away status` to read the cloud-reported state for the household or a selected side/user. Thanks @omarshahine.
 - Fixed `away off --both` reporting success without clearing away mode when all household members are away; fail explicitly when household user IDs cannot be resolved. Thanks @omarshahine.
 - Fixed daemon schedules being missed when the configured timezone and host timezone fall on different dates.
+- Fixed source installs reporting an outdated development version and added `--version` alongside `version`.
+- Enabled the verified Homebrew handoff so the tap follows signed releases.
 - Updated to Charm Log 2.0.1 for terminal-aware colors and complete severity labels, go-runewidth 0.0.29 for width fixes, and the maintained YAML v3 parser.
 - Raised the minimum Go version to 1.26.7 for HTTP fixes and prefer Go 1.26.8; updated the optional development scripts to pnpm 12.3.4 while retaining Node.js 24 support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Away-state readback, reliable household targeting and recovery, and timezone-cor
 - Fixed `away off --both` reporting success without clearing away mode when all household members are away; fail explicitly when household user IDs cannot be resolved. Thanks @omarshahine.
 - Fixed daemon schedules being missed when the configured timezone and host timezone fall on different dates.
 - Fixed source installs reporting an outdated development version and added `--version` alongside `version`.
-- Enabled the verified Homebrew handoff so the tap follows signed releases.
 - Updated to Charm Log 2.0.1 for terminal-aware colors and complete severity labels, go-runewidth 0.0.29 for width fixes, and the maintained YAML v3 parser.
 - Raised the minimum Go version to 1.26.7 for HTTP fixes and prefer Go 1.26.8; updated the optional development scripts to pnpm 12.3.4 while retaining Node.js 24 support.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ brew install steipete/tap/eightctl
 
 Prebuilt archives for macOS, Linux, and Windows on amd64 and arm64 are available from the [latest GitHub release](https://github.com/steipete/eightctl/releases/latest).
 
+Check the installed version with `eightctl --version` or `eightctl version`.
+
 To build and install from source, use Go 1.26.7 or newer:
 
 ```sh

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -16,8 +16,9 @@ import (
 
 var (
 	rootCmd = &cobra.Command{
-		Use:   "eightctl",
-		Short: "Control your Eight Sleep Pod from the terminal",
+		Use:     "eightctl",
+		Short:   "Control your Eight Sleep Pod from the terminal",
+		Version: Version,
 	}
 	logger = log.New(os.Stderr)
 )
@@ -31,6 +32,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 
 	rootCmd.PersistentFlags().String("config", "", "config file (default ~/.config/eightctl/config.yaml)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose logging")

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.2.0-dev"
+var Version = "0.2.4"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eightctl",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Go CLI for Eight Sleep Pods, with pnpm scripts for convenience",
   "engines": {


### PR DESCRIPTION
Prepare patch release 0.2.4 with the dated changelog, existing Highlights and user-interest ordering, and synchronized package/source versions. Add the conventional `--version` flag alongside `version` so source installs and packaged binaries report the same version; verify both entry points in the release-artifact CI smoke test.

The tap is still on 0.2.2. After the unified release publishes, the release operator will dispatch the existing `steipete/homebrew-tap` formula workflow with the verified release asset hashes and verify the installed version. This PR leaves the shared release workflow unchanged.

Validated with the full Go suite, release metadata/preflight checks, and real built binaries: both version commands print 0.2.4, and both honor a linker-injected version. Prior #73 tests and built-CLI away-state proof are preserved. Signing, notarization, independent draft verification, and checksums remain required.
