### PR TITLE
feat(away): add `away status` to read away mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ go.work.sum
 # .idea/
 # .vscode/
 eightctl
+
+# Clawpatch local review state
+.clawpatch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+## Clawpatch Code Review
+
+This repo uses [Clawpatch](https://clawpatch.ai) for local automated code review. Keep `.clawpatch/` ignored; it is generated runtime state containing features, findings, reports, runs, and patch attempts.
+
+Standard workflow:
+
+```bash
+clawpatch doctor
+clawpatch init          # first time only
+clawpatch map
+clawpatch review --limit 10
+clawpatch report --output .clawpatch/reports/summary.md
+clawpatch show --finding <id>
+clawpatch fix --finding <id>
+clawpatch revalidate --finding <id>
+```
+
+If this repo needs hand-authored feature coverage, keep those curated definitions in `tools/clawpatch/features/` and sync/copy them into `.clawpatch/features/` before review. Do not commit `.clawpatch/` generated state.

--- a/internal/client/eightsleep.go
+++ b/internal/client/eightsleep.go
@@ -383,6 +383,41 @@ func (c *Client) SetAwayMode(ctx context.Context, userID string, away bool) erro
 	return c.doURL(ctx, http.MethodPut, u, payload, nil)
 }
 
+// AwayModeStatus is the away-mode state for one household user.
+type AwayModeStatus struct {
+	IsAway *bool `json:"isAway"`
+}
+
+// GetAwayMode reports whether away mode is active for a specific user ID.
+// Like SetAwayMode this lives on the app API, not the client API.
+// If userID is empty, it defaults to the authenticated user.
+//
+// There is no way to derive this from the device payload: with one person
+// away Eight Sleep can duplicate the present user's ID into both top-level
+// side fields, so side assignment says nothing about away state. The
+// temperature schedule is likewise unaffected by away, which makes `status`
+// look identical either way.
+func (c *Client) GetAwayMode(ctx context.Context, userID string) (bool, error) {
+	if userID == "" {
+		if err := c.requireUser(ctx); err != nil {
+			return false, err
+		}
+		userID = c.UserID
+	}
+	u := fmt.Sprintf("%s/users/%s/away-mode", appAPIBaseURL, userID)
+	var res AwayModeStatus
+	if err := c.doURL(ctx, http.MethodGet, u, nil, &res); err != nil {
+		return false, err
+	}
+	// Treat a missing field as an error rather than defaulting to "home":
+	// silently reporting not-away for an unreadable response is the failure
+	// mode that makes an away check worse than having none.
+	if res.IsAway == nil {
+		return false, fmt.Errorf("away-mode response for %s contained no isAway state", userID)
+	}
+	return *res.IsAway, nil
+}
+
 // TempStatus represents current temperature state payload.
 type TempStatus struct {
 	CurrentLevel int `json:"currentLevel"`

--- a/internal/cmd/away.go
+++ b/internal/cmd/away.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
+	"github.com/steipete/eightctl/internal/output"
 )
 
 var awayCmd = &cobra.Command{
@@ -26,6 +28,66 @@ var awayOffCmd = &cobra.Command{
 	Use:   "off",
 	Short: "Deactivate away mode",
 	RunE:  func(cmd *cobra.Command, args []string) error { return runAway(cmd, false) },
+}
+
+var awayStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether away mode is active",
+	Long: "Report away mode per household user.\n\n" +
+		"This cannot be inferred from `eightctl status`: the temperature schedule is\n" +
+		"unaffected by away mode, so it reads the same either way.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAuthFields(); err != nil {
+			return err
+		}
+		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
+		ctx := context.Background()
+
+		targets, all, err := resolveCommandTargets(ctx, cmd, cl)
+		if err != nil {
+			return err
+		}
+		both, _ := cmd.Flags().GetBool("both")
+		if both && !all {
+			targets, err = cl.HouseholdUserTargets(ctx)
+			if err != nil {
+				return fmt.Errorf("listing household users: %w", err)
+			}
+			all = true
+		}
+
+		rows := []map[string]any{}
+		if !all && len(targets) == 0 {
+			away, err := cl.GetAwayMode(ctx, "")
+			if err != nil {
+				return err
+			}
+			rows = append(rows, map[string]any{"away": away})
+			return printAwayRows([]string{"away"}, rows)
+		}
+		for _, t := range targets {
+			away, err := cl.GetAwayMode(ctx, t.UserID)
+			if err != nil {
+				return fmt.Errorf("reading away mode for %s: %w", t.UserID, err)
+			}
+			rows = append(rows, map[string]any{
+				"side":    t.Side,
+				"name":    strings.TrimSpace(t.FirstName + " " + t.LastName),
+				"user_id": t.UserID,
+				"away":    away,
+			})
+		}
+		return printAwayRows([]string{"side", "name", "user_id", "away"}, rows)
+	},
+}
+
+func printAwayRows(headers []string, rows []map[string]any) error {
+	fields := viper.GetStringSlice("fields")
+	rows = output.FilterFields(rows, fields)
+	if len(fields) > 0 {
+		headers = fields
+	}
+	return output.Print(output.Format(viper.GetString("output")), headers, rows)
 }
 
 func runAway(cmd *cobra.Command, on bool) error {
@@ -90,6 +152,9 @@ func init() {
 	awayCmd.PersistentFlags().Bool("both", false, "Apply to every household member")
 	addTargetingFlags(awayOnCmd, true)
 	addTargetingFlags(awayOffCmd, true)
+	addTargetingFlags(awayStatusCmd, true)
+	awayStatusCmd.Flags().Bool("all-sides", false, "show away mode for all discovered household sides")
 	awayCmd.AddCommand(awayOnCmd)
 	awayCmd.AddCommand(awayOffCmd)
+	awayCmd.AddCommand(awayStatusCmd)
 }


### PR DESCRIPTION
## Problem

There is no way to ask whether away mode is on. `away` has only `on` and `off`, and away state can't be inferred from anything else the CLI exposes:

- **`status` doesn't show it.** The temperature schedule is unaffected by away mode, so it reads identically whether away is on or off.
- **Side assignment doesn't show it either.** With one person away, Eight Sleep can duplicate the present user's ID into both top-level side fields — which is exactly why `resolveSideAssignments` already prefers `awaySides` for the stable mapping.

So an operator can set away and have no way to confirm it landed, and automation can only write, never verify. I hit this directly: a pod had both sides away, and nothing in `eightctl` could tell me.

## Change

`GetAwayMode` against the same app-API endpoint `SetAwayMode` already writes to:

```
GET {APP_API}/users/{id}/away-mode  ->  { isAway }
```

A response with no `isAway` is an **error**, not a default of `false`. Reporting "not away" for an unreadable response is the failure mode that makes an away check worse than not having one.

`away status` reuses the existing targeting helpers, so `--side`, `--target-user-id`, `--all-sides` and `--both` behave as they do elsewhere, and output goes through `output.Print` for table/json/csv plus `--fields`.

## Verification

Against a live pod with both sides set away from the Eight Sleep app:

```
$ eightctl away status --both
side   name          user_id                           away
left   Omar Shahine  b00bbaf3...                       true
right  Lora Shahine  6354ffd8...                       true
```

The same pod reports an unchanged `smart:bedtime` schedule from `status` — the case that previously made away state unanswerable.

`make test` passes. Independent of #77; branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFhd1rcXuwUchP7o5bxcdM