### PR TITLE
feat(tokencache): opt-in file token storage for cgo source builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ eightctl status --fields side,name,mode,level
 
 `eightctl` authenticates against Eight Sleep's OAuth service and caches tokens in the operating system keyring, with a file-backed fallback. Reusing cached tokens reduces login traffic, but the provider can still return rate-limit errors.
 
+### Token storage
+
+Where the cached token lands depends on which keyring backends were compiled in.
+
+**Released binaries already use the file backend on macOS.** The pinned keyring library registers its Keychain backend only under a `darwin && cgo` build constraint, and releases are built with `CGO_ENABLED=0`, so the Keychain backend is not present and the file backend is selected with no configuration. Nothing below changes that.
+
+A **cgo-enabled source build** (`go install`, or `make install` on a Mac with a C toolchain) does get the Keychain backend, and with it a problem on unattended hosts. A Keychain item's ACL is bound to the code identity that created it, so rebuilding or reinstalling invalidates it and the next command raises a consent dialog. Where nobody can answer that dialog the process simply blocks, which to a scheduler is indistinguishable from a hang.
+
+For that case, `keyring_backend: file` pins storage to the file backend, which has no such binding:
+
+```yaml
+keyring_backend: file   # or EIGHTCTL_KEYRING_BACKEND=file
+```
+
+**Understand the tradeoff.** The file backend is encrypted with a fixed constant compiled into the binary, not a secret you hold. Its real protection is filesystem permissions: anyone who can read `~/.config/eightctl/keyring` can decrypt the token in it. Where an OS keyring backend is available it is the stronger option and remains the default, so set this only when an unattended process must not block on a dialog, and protect the directory accordingly (`chmod 700 ~/.config/eightctl`).
+
+The pin changes only where tokens are *stored*. It never narrows what clearing them covers: logout always reaches both backends whatever this setting says, so pinning cannot leave a usable session behind in the store you stopped reading from.
+
 `eightctl logout` removes the selected account's local cached token from reachable stores. It returns an error if a reachable store refuses deletion, even when another store clears successfully. An unavailable store remains tolerated if another opens. Logout does not revoke tokens at Eight Sleep; an already-issued token remains valid at the service until it expires.
 
 The API is undocumented and cloud-only. The [project specification](docs/spec.md#reality-of-the-api) records the current contract, while [CHANGELOG.md](CHANGELOG.md) tracks endpoint removals and compatibility changes.

--- a/internal/client/tokencache_backend_switch_test.go
+++ b/internal/client/tokencache_backend_switch_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/99designs/keyring"
+	"github.com/steipete/eightctl/internal/tokencache"
+)
+
+// recordingAPI stands in for the Eight Sleep API, recording the bearer
+// credential on every request and issuing a fresh token from its auth endpoint.
+type recordingAPI struct {
+	mu        sync.Mutex
+	bearers   []string
+	authCalls int
+	newToken  string
+}
+
+func (a *recordingAPI) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/auth") {
+			a.mu.Lock()
+			a.authCalls++
+			a.mu.Unlock()
+			fmt.Fprintf(w, `{"access_token":%q,"expires_in":3600,"userId":"uid"}`, a.newToken)
+			return
+		}
+		a.mu.Lock()
+		a.bearers = append(a.bearers, r.Header.Get("Authorization"))
+		a.mu.Unlock()
+		io.WriteString(w, `{}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := authURL
+	authURL = srv.URL + "/auth"
+	t.Cleanup(func() { authURL = prev })
+	return srv
+}
+
+func (a *recordingAPI) sawBearer(token string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, got := range a.bearers {
+		if got == "Bearer "+token {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *recordingAPI) calls() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.authCalls
+}
+
+func newSwitchClient(srv *httptest.Server) *Client {
+	c := New("user@example.test", "pw", "", "cid", "secret")
+	c.BaseURL = srv.URL
+	c.AppURL = srv.URL
+	return c
+}
+
+// Pinning storage to the file backend must not leave a usable session behind in
+// the OS keyring. Asserting on tokencache.Load alone would not settle it: the
+// question is what the production client puts on the wire afterwards.
+func TestFreshClientDoesNotSendTokenRevokedWhilePinnedToFile(t *testing.T) {
+	primary := keyring.NewArrayKeyring(nil)
+	file := keyring.NewArrayKeyring(nil)
+	defer tokencache.SetOpenKeyringForTest(func() (keyring.Keyring, error) { return primary, nil })()
+	defer tokencache.SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return file, nil })()
+	defer tokencache.SetFileBackendPinForTest(false)()
+
+	const stale = "stale-token-must-not-be-sent"
+	api := &recordingAPI{newToken: "fresh-token"}
+	srv := api.start(t)
+	ctx := context.Background()
+
+	// A previous, unpinned run cached a token in the OS keyring.
+	seed := newSwitchClient(srv)
+	if err := tokencache.Save(seed.Identity(), stale, time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatalf("seeding primary backend: %v", err)
+	}
+
+	// Non-vacuity: before logout, a fresh client really does send that token.
+	before := newSwitchClient(srv)
+	if err := before.do(ctx, http.MethodGet, "/probe", nil, nil, nil); err != nil {
+		t.Fatalf("pre-logout request: %v", err)
+	}
+	if !api.sawBearer(stale) {
+		t.Fatal("setup is vacuous: the cached token was never sent before logout")
+	}
+	if api.calls() != 0 {
+		t.Fatalf("pre-logout client should have used the cache, not re-authenticated (%d auth calls)", api.calls())
+	}
+
+	// This run is pinned to the file backend, as `keyring_backend: file` does.
+	unpin := tokencache.SetFileBackendPinForTest(true)
+	if err := tokencache.Clear(seed.Identity()); err != nil {
+		t.Fatalf("logout while pinned to file: %v", err)
+	}
+	unpin()
+
+	// A later unpinned run must re-authenticate, not resurrect the revoked token.
+	after := newSwitchClient(srv)
+	if err := after.do(ctx, http.MethodGet, "/probe", nil, nil, nil); err != nil {
+		t.Fatalf("post-logout request: %v", err)
+	}
+	if len(api.bearers) < 2 {
+		t.Fatalf("expected a post-logout request to reach the API, saw %d", len(api.bearers))
+	}
+	switch got := api.bearers[len(api.bearers)-1]; got {
+	case "Bearer " + stale:
+		t.Fatal("a fresh client sent the revoked token after logout across a backend switch")
+	case "Bearer fresh-token":
+		// Re-authenticated, as it must.
+	default:
+		t.Fatalf("post-logout request should carry a newly issued token, got %q", got)
+	}
+	if api.calls() != 1 {
+		t.Fatalf("expected exactly one re-authentication after logout, got %d", api.calls())
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -105,6 +105,11 @@ func initConfig() {
 	viper.SetDefault("output", cfg.Output)
 	viper.SetDefault("fields", cfg.Fields)
 	viper.SetDefault("verbose", cfg.Verbose)
+	viper.SetDefault("keyring_backend", cfg.KeyringBackend)
+
+	if strings.EqualFold(strings.TrimSpace(viper.GetString("keyring_backend")), "file") {
+		tokencache.UseFileBackend()
+	}
 
 	if err := config.WarnInsecurePerms(viper.ConfigFileUsed()); err != nil {
 		logger.Warn(err.Error())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	Output       string   `mapstructure:"output"`
 	Fields       []string `mapstructure:"fields"`
 	Verbose      bool     `mapstructure:"verbose"`
+	// KeyringBackend selects where the cached auth token lives. "file" pins the
+	// file backend and never touches the OS keyring; empty keeps the default
+	// (OS keyring first, file as fallback). Env: EIGHTCTL_KEYRING_BACKEND.
+	KeyringBackend string `mapstructure:"keyring_backend"`
 }
 
 // Load configures v, reads the selected file, and unmarshals Config.

--- a/internal/tokencache/tokencache.go
+++ b/internal/tokencache/tokencache.go
@@ -40,7 +40,48 @@ type Identity struct {
 var (
 	openKeyring     = defaultOpenKeyring
 	openFileKeyring = defaultOpenFileKeyring
+	// pinFileBackend routes Save/Load to the file backend only. See UseFileBackend.
+	pinFileBackend bool
 )
+
+// UseFileBackend pins reads and writes to the file backend, so the OS keyring is
+// never opened for Save or Load.
+//
+// This matters only where an OS keyring backend is actually compiled in. The
+// pinned github.com/99designs/keyring registers its macOS Keychain backend under
+// a "darwin && cgo" build constraint, and released eightctl binaries are built
+// with CGO_ENABLED=0, so those already select the file backend on macOS with no
+// configuration at all. The case this option addresses is a cgo-enabled source
+// build (go install, or make install on a Mac with a C toolchain), where the
+// Keychain backend is present.
+//
+// There, a Keychain item's ACL is bound to the code identity that created it, so
+// rebuilding or reinstalling invalidates it and the next command blocks on a
+// consent dialog. On a headless or unattended host nobody sees that dialog, so it
+// is indistinguishable from a hang. The file backend has no such binding.
+//
+// This deliberately sets a flag rather than reassigning openKeyring. Clear() must
+// keep reaching the real OS keyring whatever the pin says: pinning where tokens
+// are stored must not narrow what logout revokes.
+func UseFileBackend() {
+	pinFileBackend = true
+}
+
+// primaryOpener is the backend Save and Load use. Clear does not consult it.
+func primaryOpener() func() (keyring.Keyring, error) {
+	if pinFileBackend {
+		return openFileKeyring
+	}
+	return openKeyring
+}
+
+// SetFileBackendPinForTest sets the file-backend pin and returns a restore func,
+// so packages outside tokencache can exercise both sides of the switch.
+func SetFileBackendPinForTest(pin bool) (restore func()) {
+	prev := pinFileBackend
+	pinFileBackend = pin
+	return func() { pinFileBackend = prev }
+}
 
 // SetOpenKeyringForTest swaps the keyring opener; it returns a restore func.
 // Not safe for concurrent tests; intended for isolated test scenarios.
@@ -83,6 +124,12 @@ func defaultOpenFileKeyring() (keyring.Keyring, error) {
 	})
 }
 
+// filePassword returns the encryption password for the file backend.
+//
+// It is a fixed, publicly known constant, not a user-held secret, so the file
+// backend's protection boundary is filesystem permissions: anyone who can read
+// the keyring directory can decrypt what is in it. See UseFileBackend and the
+// README section "Token storage".
 func filePassword(_ string) (string, error) {
 	return serviceName + "-fallback", nil
 }
@@ -102,10 +149,14 @@ func Save(id Identity, token string, expiresAt time.Time, userID string) error {
 		Data:  data,
 	}
 
-	primaryErr := trySetWith(openKeyring, item)
+	primaryErr := trySetWith(primaryOpener(), item)
 	if primaryErr == nil {
 		log.Debug("keyring saved token")
 		return nil
+	}
+	if pinFileBackend {
+		// The file backend is the pinned target; there is nothing to fall back to.
+		return primaryErr
 	}
 	log.Debug("primary keyring set failed; falling back to file backend", "error", primaryErr)
 
@@ -131,7 +182,7 @@ func trySetWith(opener func() (keyring.Keyring, error), item keyring.Item) error
 // multiple household userIDs. The cached UserID is informational metadata for
 // callers that want to recover "which userID was primary at auth time."
 func Load(id Identity) (*CachedToken, error) {
-	cached, err := loadFrom(openKeyring, id)
+	cached, err := loadFrom(primaryOpener(), id)
 	if err == nil {
 		return cached, nil
 	}

--- a/internal/tokencache/tokencache_test.go
+++ b/internal/tokencache/tokencache_test.go
@@ -495,3 +495,69 @@ func realFileKeyring(t *testing.T) (func() (keyring.Keyring, error), string) {
 	}
 	return opener, dir
 }
+
+// Pinning storage to the file backend must not narrow what logout revokes. An
+// earlier revision implemented the pin by aliasing openKeyring to
+// openFileKeyring, so Clear() removed the file entry twice and left the primary
+// entry intact: logout reported success while a usable session survived in the
+// OS keyring, and it came back the moment the pin was removed.
+func TestClearRevokesPrimaryWhenFileBackendPinned(t *testing.T) {
+	primary := keyring.NewArrayKeyring(nil)
+	file := keyring.NewArrayKeyring(nil)
+
+	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) { return primary, nil })()
+	defer SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return file, nil })()
+	defer SetFileBackendPinForTest(false)()
+
+	id := Identity{BaseURL: "https://example.test/v1", ClientID: "cid", Email: "user@example.test"}
+	if err := Save(id, "primary-token", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatalf("seeding primary backend: %v", err)
+	}
+	if _, err := Load(id); err != nil {
+		t.Fatalf("primary token should load before logout: %v", err)
+	}
+
+	// Pin to file, as `keyring_backend: file` does, then log out.
+	restore := SetFileBackendPinForTest(true)
+	if err := Clear(id); err != nil {
+		t.Fatalf("Clear returned an error: %v", err)
+	}
+	restore()
+
+	// Unpinned: the primary entry must be gone, not merely unreachable.
+	if cached, err := Load(id); err == nil {
+		t.Fatalf("logout left a usable session in the primary backend: %+v", cached)
+	}
+}
+
+// The pin routes Save and Load to the file backend without touching the OS keyring.
+func TestPinRoutesSaveAndLoadToFileBackend(t *testing.T) {
+	primary := keyring.NewArrayKeyring(nil)
+	file := keyring.NewArrayKeyring(nil)
+	primaryOpens := 0
+
+	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) {
+		primaryOpens++
+		return primary, nil
+	})()
+	defer SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return file, nil })()
+	defer SetFileBackendPinForTest(true)()
+
+	id := Identity{BaseURL: "https://example.test/v1", ClientID: "cid", Email: "user@example.test"}
+	if err := Save(id, "file-token", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatalf("Save while pinned: %v", err)
+	}
+	cached, err := Load(id)
+	if err != nil {
+		t.Fatalf("Load while pinned: %v", err)
+	}
+	if cached.Token != "file-token" {
+		t.Fatalf("unexpected token %q", cached.Token)
+	}
+	if primaryOpens != 0 {
+		t.Fatalf("pinned Save/Load opened the OS keyring %d times, expected 0", primaryOpens)
+	}
+	if keys, _ := file.Keys(); len(keys) == 0 {
+		t.Fatal("pinned Save did not write to the file backend")
+	}
+}


### PR DESCRIPTION
Rebased onto current `main` and reduced to the storage selector alone. One commit, one question.

## What changed since the last review

The logout contract that shared this branch **landed separately in #84**, so it is gone from here. What remains is the selector.

More importantly, @steipete's finding was right and it corrected this PR's premise. I verified all three parts independently:

| Claim | Verified |
|---|---|
| Releases build with `CGO_ENABLED=0` | `.goreleaser.yaml:15`, covering `darwin_amd64` and `darwin_arm64` |
| Keychain backend is cgo-gated | keyring v1.2.2 `keychain.go:1` — `//go:build darwin && cgo` |
| So released macOS binaries already use the file backend | follows: the backend is never compiled in |

**The old body and README were wrong.** They said the OS keyring is the default on macOS and that this option changes where release users' tokens live. It doesn't. Release users are already on the file backend, with no configuration and no opt-in. That text is replaced rather than patched.

## What this option is actually for

A **cgo-enabled source build**: `go install`, or `make install` on a Mac with a C toolchain. There the Keychain backend is present, a rebuild invalidates the item's ACL, and an unattended host blocks on a consent dialog nobody can answer.

That narrows the security question considerably. This does not move release users from Keychain protection to filesystem protection, because they were never on Keychain protection. It adds an opt-in for source builds that currently have it.

## The tradeoff, unchanged

The file backend's password is a fixed constant compiled into the binary, not a user secret, so filesystem permissions carry the boundary. Where an OS keyring backend *is* compiled in it remains the default and the stronger option. The README says this plainly.

## Logout is not narrowed

The pin is a flag consulted only by `Save` and `Load`, via `primaryOpener()`. `Clear()` always reaches both real backends. Covered at two levels:

- `TestClearRevokesPrimaryWhenFileBackendPinned` — seed primary, pin, clear, unpin, require the primary entry to be gone.
- `TestFreshClientDoesNotSendTokenRevokedWhilePinnedToFile` — the same sequence against the production client, requiring a fresh client to re-authenticate rather than put the revoked token on the wire. Asserts non-vacuity first: before logout, the cached token really is sent.
- `TestPinRoutesSaveAndLoadToFileBackend` — the pin never opens the OS keyring for Save or Load.

Restoring the aliasing bug fails both guards:

```
FAIL: logout left a usable session in the primary backend
FAIL: a fresh client sent the revoked token after logout across a backend switch
```

## Worth weighing against this PR

A separate finding says the re-prompt's cause is the ad-hoc signature from `make install`: an ad-hoc designated requirement is a literal cdhash pin, and Go does not build reproducibly, so **every** rebuild invalidates the ACL. If that is the cause, signing local builds with a stable identity fixes it closer to the root, and this selector is a workaround. That remedy is untested — it needs a machine with a Developer ID.

Raising it because it argues against merging this as-is. I am happy to close in favor of the signing fix, or to keep this as a verified escape hatch while that is proven out. Your call.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test ./...` — all packages pass
- Rebased on `db84b93`; conflict with main resolved by dropping what #84 already landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtVNrHHZRwkbZhk34UxLi8
