### PR TITLE
build: refresh release tooling and prepare 0.2.5 notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7.2.3
         with:
           distribution: goreleaser
-          version: v2.18.0
+          version: v2.18.1
           install-only: true
 
       - name: Release artifact smoke test

--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -51,7 +51,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7.2.3
         with:
           distribution: goreleaser
-          version: v2.18.0
+          version: v2.18.1
           args: release --clean --config /tmp/.goreleaser.yaml --release-notes /tmp/release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ## Unreleased
 
+### Highlights
+
+Local source builds gain a portable install helper with macOS signature verification.
+
+- Added `make build` and `make install`, with a configurable destination, directory creation, and macOS signing and verification after replacement. Thanks @omarshahine.
+- Updated repository-owned GoReleaser tooling to 2.18.1 for archive-path fixes, dependency security updates, and temporary-directory cleanup improvements.
+
 ## 0.2.4 - 2026-09-05
 
 ### Highlights


### PR DESCRIPTION
Prepare the 0.2.5 patch notes for the local build/install helper in #77 and update repository-owned GoReleaser pins from 2.18.0 to 2.18.1. The patch release includes archive-path reporting fixes, dependency security updates, and temporary-directory cleanup improvements in GoReleaser.

This is the only prepared PR that edits CHANGELOG.md. Merge it after #77; both branches are based independently on main. Released changelog sections are unchanged, and no version, tag, or release is created here.

The dependency sweep found direct Go dependencies and pnpm 12.3.4 current. Retain Go 1.26.7 minimum / 1.26.8 preferred to preserve the existing macOS compatibility decision. Hold the new untagged Ultraviolet revision and unused or dependency-test-only graph updates.

Validation results and exact-head CI are recorded in the proof comment.
