### PR TITLE
fix(tokencache): report incomplete logout cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ eightctl status --fields side,name,mode,level
 
 `eightctl` authenticates against Eight Sleep's OAuth service and caches tokens in the operating system keyring, with a file-backed fallback. Reusing cached tokens reduces login traffic, but the provider can still return rate-limit errors.
 
+`eightctl logout` removes the selected account's local cached token from reachable stores. It returns an error if a reachable store refuses deletion, even when another store clears successfully. An unavailable store remains tolerated if another opens. Logout does not revoke tokens at Eight Sleep; an already-issued token remains valid at the service until it expires.
+
 The API is undocumented and cloud-only. The [project specification](docs/spec.md#reality-of-the-api) records the current contract, while [CHANGELOG.md](CHANGELOG.md) tracks endpoint removals and compatibility changes.
 
 ## Development

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -19,6 +19,8 @@ Eight Sleep Pod power/control + data-export CLI, written in Go. Targets macOS/Li
 ## CLI Surface (implemented)
 Core: `on`, `off`, `temp <level>`, `status`, `whoami`, `logout`, `version`.
 
+`logout` removes the selected identity's local cached token from reachable stores; it does not revoke tokens at the service. Deletion failures from a reachable store produce a nonzero exit status, including after partial cleanup. An unavailable backend is tolerated if another opens; if neither opens, logout fails.
+
 Away mode:
 - `away on|off|status`
 

--- a/internal/tokencache/tokencache.go
+++ b/internal/tokencache/tokencache.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,29 +186,74 @@ func loadFrom(opener func() (keyring.Keyring, error), id Identity) (*CachedToken
 	return &cached, nil
 }
 
+// Clear revokes the cached token from every backend it could be in.
+//
+// The two failure modes are not equivalent and must not be folded together. A
+// backend that will not open holds nothing this process can leak, so tolerating
+// it is correct. A backend that opens and then refuses removal may still hold a
+// token a later command would send as a bearer credential. Returning nil there
+// would report a session as revoked while it is still usable, which is the one
+// answer logout must never give.
 func Clear(id Identity) error {
-	primaryErr := clearFrom(openKeyring, id)
-	fallbackErr := clearFrom(openFileKeyring, id)
-	if primaryErr != nil && fallbackErr != nil {
+	primaryOpened, primaryErr := clearFrom(openKeyring, id)
+	fileOpened, fileErr := clearFrom(openFileKeyring, id)
+
+	// Opened, then refused: a usable session may survive. Say so.
+	if primaryOpened && primaryErr != nil {
 		return primaryErr
+	}
+	if fileOpened && fileErr != nil {
+		return fileErr
+	}
+	// Neither backend opened, so nothing was revoked anywhere.
+	if !primaryOpened && !fileOpened {
+		if primaryErr != nil {
+			return primaryErr
+		}
+		return fileErr
 	}
 	return nil
 }
 
-func clearFrom(opener func() (keyring.Keyring, error), id Identity) error {
+// clearFrom removes id's cached token from a single backend. It reports whether
+// the backend could be opened at all, so Clear can tell "nothing to revoke
+// here" apart from "revocation was refused".
+func clearFrom(opener func() (keyring.Keyring, error), id Identity) (opened bool, err error) {
 	ring, err := opener()
 	if err != nil {
-		return err
+		return false, err
 	}
 	for _, key := range []string{storageKey(id), cacheKey(id)} {
 		if err := ring.Remove(key); err != nil {
-			if err == keyring.ErrKeyNotFound || os.IsNotExist(err) || isIgnorableLegacyKeyError(err) {
+			if isAbsentOrUnnameable(err) {
 				continue
 			}
-			return err
+			return true, err
 		}
 	}
-	return nil
+	return true, nil
+}
+
+// isAbsentOrUnnameable reports whether a removal error means there is nothing
+// here to revoke: the item is already gone, or the key cannot name a file on
+// this platform at all (the legacy colon/pipe keys on Windows).
+//
+// Permission denied is deliberately excluded. os.Remove reports it as an
+// *os.PathError and isIgnorableLegacyKeyError ignores every *os.PathError, so
+// folding the two together would let a still-readable token survive a logout
+// that reported success. A token we are not allowed to delete is a token that
+// survives, and Clear has to say so.
+func isAbsentOrUnnameable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	if errors.Is(err, fs.ErrPermission) {
+		return false
+	}
+	return isIgnorableLegacyKeyError(err)
 }
 
 func cacheKey(id Identity) string {

--- a/internal/tokencache/tokencache.go
+++ b/internal/tokencache/tokencache.go
@@ -7,7 +7,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"charm.land/log/v2"
@@ -186,46 +188,34 @@ func loadFrom(opener func() (keyring.Keyring, error), id Identity) (*CachedToken
 	return &cached, nil
 }
 
-// Clear revokes the cached token from every backend it could be in.
-//
-// The two failure modes are not equivalent and must not be folded together. A
-// backend that will not open holds nothing this process can leak, so tolerating
-// it is correct. A backend that opens and then refuses removal may still hold a
-// token a later command would send as a bearer credential. Returning nil there
-// would report a session as revoked while it is still usable, which is the one
-// answer logout must never give.
+// Clear removes the identity's local token cache from reachable backends.
+// An unavailable backend is tolerated if another opens, but removal failures
+// from an opened backend are returned. This does not revoke tokens at the service.
 func Clear(id Identity) error {
 	primaryOpened, primaryErr := clearFrom(openKeyring, id)
 	fileOpened, fileErr := clearFrom(openFileKeyring, id)
 
-	// Opened, then refused: a usable session may survive. Say so.
 	if primaryOpened && primaryErr != nil {
 		return primaryErr
 	}
 	if fileOpened && fileErr != nil {
 		return fileErr
 	}
-	// Neither backend opened, so nothing was revoked anywhere.
 	if !primaryOpened && !fileOpened {
-		if primaryErr != nil {
-			return primaryErr
-		}
-		return fileErr
+		return primaryErr
 	}
 	return nil
 }
 
-// clearFrom removes id's cached token from a single backend. It reports whether
-// the backend could be opened at all, so Clear can tell "nothing to revoke
-// here" apart from "revocation was refused".
+// clearFrom distinguishes an unavailable backend from an incomplete removal.
 func clearFrom(opener func() (keyring.Keyring, error), id Identity) (opened bool, err error) {
 	ring, err := opener()
 	if err != nil {
 		return false, err
 	}
-	for _, key := range []string{storageKey(id), cacheKey(id)} {
+	for i, key := range []string{storageKey(id), cacheKey(id)} {
 		if err := ring.Remove(key); err != nil {
-			if isAbsentOrUnnameable(err) {
+			if isAbsentOrUnnameable(err, i == 1) {
 				continue
 			}
 			return true, err
@@ -234,26 +224,14 @@ func clearFrom(opener func() (keyring.Keyring, error), id Identity) (opened bool
 	return true, nil
 }
 
-// isAbsentOrUnnameable reports whether a removal error means there is nothing
-// here to revoke: the item is already gone, or the key cannot name a file on
-// this platform at all (the legacy colon/pipe keys on Windows).
-//
-// Permission denied is deliberately excluded. os.Remove reports it as an
-// *os.PathError and isIgnorableLegacyKeyError ignores every *os.PathError, so
-// folding the two together would let a still-readable token survive a logout
-// that reported success. A token we are not allowed to delete is a token that
-// survives, and Clear has to say so.
-func isAbsentOrUnnameable(err error) bool {
-	if err == nil {
-		return false
-	}
+func isAbsentOrUnnameable(err error, legacy bool) bool {
 	if errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, fs.ErrNotExist) {
 		return true
 	}
-	if errors.Is(err, fs.ErrPermission) {
-		return false
-	}
-	return isIgnorableLegacyKeyError(err)
+	// Only legacy keys can contain Windows-invalid filename characters. Other
+	// PathErrors (permissions, read-only mounts, I/O failures) may leave a token.
+	const windowsInvalidName syscall.Errno = 123
+	return legacy && runtime.GOOS == "windows" && errors.Is(err, windowsInvalidName)
 }
 
 func cacheKey(id Identity) string {

--- a/internal/tokencache/tokencache_test.go
+++ b/internal/tokencache/tokencache_test.go
@@ -1,10 +1,13 @@
 package tokencache
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -351,9 +354,6 @@ func TestClearReportsRefusedRemoval(t *testing.T) {
 	}
 }
 
-// A backend that cannot be opened is not evidence a token survived there, so it
-// must not turn a successful logout into a failure.
-
 func TestClearToleratesUnopenableBackend(t *testing.T) {
 	file := keyring.NewArrayKeyring(nil)
 	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) {
@@ -373,8 +373,6 @@ func TestClearToleratesUnopenableBackend(t *testing.T) {
 	}
 }
 
-// Neither backend reachable means nothing was revoked anywhere; logout must say so.
-
 func TestClearFailsWhenNoBackendOpens(t *testing.T) {
 	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) {
 		return nil, errors.New("primary unavailable")
@@ -388,9 +386,6 @@ func TestClearFailsWhenNoBackendOpens(t *testing.T) {
 		t.Fatal("Clear reported success with no reachable backend")
 	}
 }
-
-// realFileKeyring opens the production file backend rooted in a temp dir, and
-// returns the directory holding the stored items.
 
 func TestClearReportsPermissionDeniedFileRemoval(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -428,6 +423,60 @@ func TestClearReportsPermissionDeniedFileRemoval(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("logout reported success while a readable token survived a denied deletion")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("expected permission failure, got %v", err)
+	}
+}
+
+func TestClearReportsPathFailures(t *testing.T) {
+	for _, cause := range []error{os.ErrPermission, syscall.EROFS, syscall.EIO, syscall.EINVAL} {
+		t.Run(cause.Error(), func(t *testing.T) {
+			refusal := &os.PathError{Op: "remove", Path: "cached-token", Err: cause}
+			for _, primaryFails := range []bool{true, false} {
+				backing := keyring.NewArrayKeyring(nil)
+				failing := refusingKeyring{Keyring: backing, err: refusal}
+				empty := keyring.NewArrayKeyring(nil)
+				primary, fallback := keyring.Keyring(failing), keyring.Keyring(empty)
+				if !primaryFails {
+					primary, fallback = empty, failing
+				}
+				restorePrimary := SetOpenKeyringForTest(func() (keyring.Keyring, error) { return primary, nil })
+				restoreFile := SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return fallback, nil })
+				id := Identity{BaseURL: "https://example.test/v1", ClientID: "cid", Email: "user@example.test"}
+				data, err := json.Marshal(CachedToken{Token: "synthetic-survivor", ExpiresAt: time.Now().Add(time.Hour)})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := backing.Set(keyring.Item{Key: storageKey(id), Data: data}); err != nil {
+					t.Fatal(err)
+				}
+				clearErr := Clear(id)
+				_, loadErr := Load(id)
+				restorePrimary()
+				restoreFile()
+				if !errors.Is(clearErr, cause) || loadErr != nil {
+					t.Fatalf("primaryFails=%v: clear=%v load=%v", primaryFails, clearErr, loadErr)
+				}
+			}
+		})
+	}
+}
+
+func TestClearRemovalErrorClassification(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		for _, missing := range []error{keyring.ErrKeyNotFound, os.ErrNotExist} {
+			if !isAbsentOrUnnameable(fmt.Errorf("wrapped: %w", missing), legacy) {
+				t.Fatalf("missing item should be ignored: %v", missing)
+			}
+		}
+		if isAbsentOrUnnameable(nil, legacy) {
+			t.Fatal("nil is not a removal error")
+		}
+		invalidName := &os.PathError{Op: "remove", Path: "legacy:key", Err: syscall.Errno(123)}
+		if got, want := isAbsentOrUnnameable(invalidName, legacy), legacy && runtime.GOOS == "windows"; got != want {
+			t.Fatalf("legacy=%v: Windows invalid-name error ignored=%v, want %v", legacy, got, want)
+		}
 	}
 }
 

--- a/internal/tokencache/tokencache_test.go
+++ b/internal/tokencache/tokencache_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -313,4 +314,135 @@ func TestIgnorableLegacyKeyError(t *testing.T) {
 	if isIgnorableLegacyKeyError(errors.New("boom")) {
 		t.Fatalf("generic error should not be ignorable")
 	}
+}
+
+type refusingKeyring struct {
+	keyring.Keyring
+	err error
+}
+
+func (r refusingKeyring) Remove(string) error { return r.err }
+
+func TestClearReportsRefusedRemoval(t *testing.T) {
+	backing := keyring.NewArrayKeyring(nil)
+	refusalErr := errors.New("keyring refused removal")
+	primary := refusingKeyring{Keyring: backing, err: refusalErr}
+	file := keyring.NewArrayKeyring(nil)
+
+	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) { return primary, nil })()
+	defer SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return file, nil })()
+
+	id := Identity{BaseURL: "https://example.test/v1", ClientID: "cid", Email: "user@example.test"}
+	if err := Save(id, "surviving-token", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatalf("seeding primary backend: %v", err)
+	}
+
+	err := Clear(id)
+
+	if err == nil {
+		t.Fatal("Clear reported success while the primary backend refused removal")
+	}
+	if !errors.Is(err, refusalErr) {
+		t.Fatalf("Clear should surface the refusal, got %v", err)
+	}
+	// Not vacuous: the token really did survive, which is why the error matters.
+	if _, loadErr := Load(id); loadErr != nil {
+		t.Fatalf("expected the refused token to still be loadable, got %v", loadErr)
+	}
+}
+
+// A backend that cannot be opened is not evidence a token survived there, so it
+// must not turn a successful logout into a failure.
+
+func TestClearToleratesUnopenableBackend(t *testing.T) {
+	file := keyring.NewArrayKeyring(nil)
+	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) {
+		return nil, errors.New("no OS keyring on this host")
+	})()
+	defer SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return file, nil })()
+
+	id := Identity{BaseURL: "https://example.test/v1", ClientID: "cid", Email: "user@example.test"}
+	if err := Save(id, "file-token", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatalf("seeding file backend: %v", err)
+	}
+	if err := Clear(id); err != nil {
+		t.Fatalf("an unopenable backend should not fail logout, got %v", err)
+	}
+	if cached, err := Load(id); err == nil {
+		t.Fatalf("logout left a usable session: %+v", cached)
+	}
+}
+
+// Neither backend reachable means nothing was revoked anywhere; logout must say so.
+
+func TestClearFailsWhenNoBackendOpens(t *testing.T) {
+	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) {
+		return nil, errors.New("primary unavailable")
+	})()
+	defer SetOpenFileKeyringForTest(func() (keyring.Keyring, error) {
+		return nil, errors.New("file unavailable")
+	})()
+
+	id := Identity{BaseURL: "https://example.test/v1", ClientID: "cid", Email: "user@example.test"}
+	if err := Clear(id); err == nil {
+		t.Fatal("Clear reported success with no reachable backend")
+	}
+}
+
+// realFileKeyring opens the production file backend rooted in a temp dir, and
+// returns the directory holding the stored items.
+
+func TestClearReportsPermissionDeniedFileRemoval(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions do not block unlink the same way on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the directory permissions this test relies on")
+	}
+
+	fileOpener, dir := realFileKeyring(t)
+	defer SetOpenKeyringForTest(func() (keyring.Keyring, error) {
+		return nil, errors.New("no OS keyring on this host")
+	})()
+	defer SetOpenFileKeyringForTest(fileOpener)()
+
+	id := Identity{BaseURL: "https://example.test/v1", ClientID: "cid", Email: "user@example.test"}
+	if err := Save(id, "denied-token", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatalf("seeding file backend: %v", err)
+	}
+
+	// Deny unlink while leaving the item readable.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	err := Clear(id)
+
+	// Non-vacuous: the token really did survive the failed logout.
+	if cached, loadErr := Load(id); loadErr != nil {
+		t.Fatalf("test is vacuous, the token did not survive: %v", loadErr)
+	} else if cached.Token != "denied-token" {
+		t.Fatalf("unexpected surviving token %q", cached.Token)
+	}
+
+	if err == nil {
+		t.Fatal("logout reported success while a readable token survived a denied deletion")
+	}
+}
+
+// realFileKeyring opens the production file backend rooted in a temp dir, and
+// returns the directory holding the stored items.
+func realFileKeyring(t *testing.T) (func() (keyring.Keyring, error), string) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "keyring")
+	opener := func() (keyring.Keyring, error) {
+		return keyring.Open(keyring.Config{
+			ServiceName:      serviceName + "-test",
+			AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+			FileDir:          dir,
+			FilePasswordFunc: filePassword,
+		})
+	}
+	return opener, dir
 }


### PR DESCRIPTION
Logout can print `Logged out (token cache cleared)` even when a reachable store refuses removal and the cached token survives. Report an error for that incomplete cleanup while preserving successful cleanup, missing-token handling, and tolerance for an unavailable backend when another opens.

Omar's original fix separated backend-open failures from deletion failures. Maintainer repair also narrows legacy-filename tolerance to Windows ERROR_INVALID_NAME on the legacy key: read-only filesystem, I/O, invalid-argument, and permission failures now propagate. README/spec wording describes local cache removal accurately; logout does not revoke tokens at Eight Sleep.

Validation:

- Full suite on Go 1.26.8 and the supported Go 1.26.7 minimum; token-cache race tests; formatting and lint clean; core coverage 87.9%.
- Built and ran the real CLI with the release configuration (`CGO_ENABLED=0`) and an isolated synthetic file cache. Denied unlink yields exit 0 on main and exit 1 after the fix; the cached token remains loadable after refusal. Restoring permissions allows successful cleanup; repeated logout succeeds.
- Mounted a synthetic read-only disk image and repeated the real CLI run. Both main and the original PR head falsely reported success; the repaired candidate reports a read-only filesystem error and exit 1.
- Regression tests fail against main for refused/permission-denied deletion, and against the original PR for read-only/I/O/invalid-argument deletion errors. Windows token-cache tests cross-compile.

Release-note credit is collected in the final notes/dependency PR #85, to merge after this PR. Storage-selection policy is tracked separately in #82.
