### PR TITLE
chore: refresh terminal dependency and prepare 0.2.5 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ### Highlights
 
-Local source builds gain a portable install helper with macOS signature verification.
+Logout now reports incomplete token-cache cleanup, and local source builds gain a portable install helper with macOS signature verification.
 
+- Fixed logout reporting success when a reachable token store refuses deletion, including permission, read-only filesystem, and I/O failures. Thanks @omarshahine.
 - Added `make build` and `make install`, with a configurable destination, directory creation, and macOS signing and verification after replacement. Thanks @omarshahine.
+- Updated Ultraviolet for terminal rendering, resize, and styled-content parsing fixes.
 - Updated repository-owned GoReleaser tooling to 2.18.1 for archive-path fixes, dependency security updates, and temporary-directory cleanup improvements.
 
 ## 0.2.4 - 2026-09-05

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.6 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260906173415-0277a179edd9 // indirect
 	github.com/charmbracelet/x/ansi v0.11.8 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XB
 github.com/99designs/keyring v1.2.2/go.mod h1:wes/FrByc8j7lFOAGLGSNEg8f/PaI3cgTBqhFkHUrPk=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be h1:qEvkJy1sjJXP+yf8IH2o13NV+Rh4nIUHjaLNJ+pWxpI=
-github.com/charmbracelet/ultraviolet v0.0.0-20260812204455-68fa937c71be/go.mod h1:nAw0d9PhFp1qdzi2xhQU5YOu5sVpDIHWlaW2Uz/bCro=
+github.com/charmbracelet/ultraviolet v0.0.0-20260906173415-0277a179edd9 h1:tYBWVoMfQHTwp88mWeWH7o0uJFZqRJeEGJmeHpIR8Ms=
+github.com/charmbracelet/ultraviolet v0.0.0-20260906173415-0277a179edd9/go.mod h1:nAw0d9PhFp1qdzi2xhQU5YOu5sVpDIHWlaW2Uz/bCro=
 github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
 github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=


### PR DESCRIPTION
Refresh Ultraviolet to `v0.0.0-20260906173415-0277a179edd9` for its terminal rendering, resize, and styled-content parsing fixes, and prepare the complete 0.2.5 Unreleased notes. Go 1.26.7 remains the supported minimum and Go 1.26.8 the preferred toolchain.

Merge after #84. This branch is independent from main and contains only the module/checksum update and the consolidated release notes. The logout fix stays in #84; its release-note credit to @omarshahine is collected here alongside the previously landed install helper and GoReleaser refresh.

Validation: full test suite, 87.2% core coverage, clean lint and formatting, `go mod verify`, release metadata consistency, and a GoReleaser snapshot build. The new dependency was also tested with #84's implementation: the full suite and real-binary read-only-filesystem logout proof passed together.

Recommend patch 0.2.5 after these prepared changes land. No release, tag, or publication is included.
