### PR TITLE
chore(release): prepare v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier project history from git.
 
-## Unreleased
+## 0.2.5 - 2026-09-07
 
 ### Highlights
 

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.2.4"
+var Version = "0.2.5"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eightctl",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "Go CLI for Eight Sleep Pods, with pnpm scripts for convenience",
   "engines": {


### PR DESCRIPTION
Prepare patch release 0.2.5 for truthful logout cleanup reporting. Date the existing changelog section 2026-09-07, retaining Highlights, user-interest ordering, and contributor credit; synchronize the package and source versions.

Release metadata validation passes, and the built CLI prints 0.2.5 through both version commands. Independent review of the staged change is clean through P2. Publication will follow green CI on the finalized release commit through the existing signing/notarization workflow, followed by verified Homebrew handoff and Go module availability.
