### PR TITLE
test(client): stop the suite writing to the developer's real Keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ eightctl status --fields side,name,mode,level
 
 ## Authentication and API behavior
 
-`eightctl` authenticates against Eight Sleep's OAuth service and caches tokens in the operating system keyring, with a file-backed fallback. Reusing cached tokens reduces login traffic, but the provider can still return rate-limit errors.
+`eightctl` authenticates against Eight Sleep's OAuth service and caches tokens between commands. Published macOS binaries are built without CGO and use the file-backed cache at `~/.config/eightctl/keyring`. CGO-enabled macOS source builds prefer Keychain; other platforms use an available operating system keyring, with a file-backed fallback. Reusing cached tokens reduces login traffic, but the provider can still return rate-limit errors.
 
 `eightctl logout` removes the selected account's local cached token from reachable stores. It returns an error if a reachable store refuses deletion, even when another store clears successfully. An unavailable store remains tolerated if another opens. Logout does not revoke tokens at Eight Sleep; an already-issued token remains valid at the service until it expires.
 

--- a/internal/client/main_test.go
+++ b/internal/client/main_test.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"github.com/99designs/keyring"
+	"github.com/steipete/eightctl/internal/tokencache"
+)
+
+// TestMain keeps this package's tests off the developer's real credential store.
+//
+// Several tests drive the full authentication path, and a successful
+// authentication caches the issued token through tokencache.Save. Without this,
+// Save reaches the default opener, which on a cgo-enabled macOS build is the
+// login Keychain: running `go test ./...` wrote entries for identities like
+// test@example.com into the developer's own Keychain and left them there. A
+// released binary is built with CGO_ENABLED=0 and cannot see the Keychain, so
+// `eightctl logout` will not clean them up either.
+//
+// Pointing both openers at in-memory stores for the whole package fixes every
+// current test and any later one that reaches the cache without having to
+// remember this.
+func TestMain(m *testing.M) {
+	primary := keyring.NewArrayKeyring(nil)
+	file := keyring.NewArrayKeyring(nil)
+
+	restorePrimary := tokencache.SetOpenKeyringForTest(func() (keyring.Keyring, error) {
+		return primary, nil
+	})
+	restoreFile := tokencache.SetOpenFileKeyringForTest(func() (keyring.Keyring, error) {
+		return file, nil
+	})
+
+	code := m.Run()
+
+	restoreFile()
+	restorePrimary()
+	os.Exit(code)
+}


### PR DESCRIPTION
Client authentication tests currently write synthetic OAuth tokens to the developer's persistent credential stores. On CGO-enabled macOS builds, those entries reach Keychain and remain after the test process exits.

Install in-memory primary and fallback stores in the client package's `TestMain`, covering every test that reaches authentication. Production authentication and storage behavior stay unchanged. The README also clarifies the existing build distinction: published macOS binaries disable CGO and use the file cache, while CGO-enabled source builds prefer Keychain.

Verification:

- Full uncached test suites on macOS with Go 1.26.8 and Go 1.26.7; core coverage is 86.1%.
- Guarded compiled-test reproduction: removing `TestMain` reaches a persistent opener and fails; the same authentication test passes with `TestMain`. Guards stop access before opening any real credential store.
- Built the real CLI and ran `--version` and `--help`; formatting and golangci-lint pass.
- Final branch Codex autoreview found no actionable findings through P2; CI is green on head c12effd959914721c5e95fedab7ffff95ecee07f: https://github.com/steipete/eightctl/actions/runs/34660657496.

Contributor: @omarshahine. The changelog entry is carried by the final dependency/notes PR to keep sibling branches independent.
