### PR TITLE
chore(release): prepare v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 
 The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier project history from git.
 
-## Unreleased
+## 0.2.6 - 2026-09-11
 
 ### Highlights
 

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.2.5"
+var Version = "0.2.6"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eightctl",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "Go CLI for Eight Sleep Pods, with pnpm scripts for convenience",
   "engines": {


### PR DESCRIPTION
Prepare the authorized 0.2.6 patch release: date the existing changelog section September 11, 2026, preserving Highlights and contributor credit, and synchronize the package and source CLI versions.

The signed unified release workflow will run only after CI is green on the merged release commit. Local verification covers both supported Go versions, release metadata and preflight checks, and the built CLI version. Independent autoreview is clean.
