### PR TITLE
refactor: simplify command setup and shared power controls

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,4 +1,4 @@
-# eightctl Specification (Dec 2025)
+# eightctl Specification
 
 ## Purpose
 Eight Sleep Pod power/control + data-export CLI, written in Go. Targets macOS/Linux users who want a dependable terminal tool (incl. daemon) for pod automations, metrics export, and feature toggles that the mobile app exposes but the vendor does not document.
@@ -26,7 +26,7 @@ Away mode:
 
 Schedules & daemon:
 - `schedule list` (Autopilot smart schedule)
-- `daemon` (YAML-based scheduler with PID guard, dry-run, timezone override, optional state sync)
+- `daemon` (YAML-based scheduler with PID guard, dry-run, timezone override)
 
 Alarms:
 - `alarm list|create|update|delete`
@@ -83,11 +83,11 @@ Audio/temperature data helpers:
 
 ## Daemon Behavior
 - Reads YAML schedule (time, action on|off|temp, temperature with unit), minute tick, executes once per day, PID guard, SIGINT/SIGTERM graceful stop.
-- Optional state sync compares expected schedule state vs device and reconciles.
+- `--sync-state` is reserved and currently has no effect; the daemon does not reconcile device state.
 - Start with `eightctl daemon --config ~/.config/eightctl/config.yaml --dry-run` to validate scheduled actions without changing the pod.
 
 ## Testing & Quality Gates
-- `go test ./...` (fast compile checks) — run before handoff.
+- `go test ./...` runs unit and local HTTP integration tests.
 - `make coverage` enforces >=85% coverage on core packages (`internal/client`, `config`, `daemon`, `output`, `tokencache`).
 - Formatting via tracked `go tool mvdan.cc/gofumpt`; linting via golangci-lint v2.
 - Live checks: `eightctl status`, `metrics trends`, `tempmode nap status` with test creds to validate auth + userId resolution.

--- a/internal/client/targets.go
+++ b/internal/client/targets.go
@@ -17,7 +17,7 @@ type HouseholdUserTarget struct {
 }
 
 func (t HouseholdUserTarget) DisplayName() string {
-	name := strings.TrimSpace(strings.TrimSpace(t.FirstName + " " + t.LastName))
+	name := strings.TrimSpace(t.FirstName + " " + t.LastName)
 	if name != "" {
 		return name
 	}

--- a/internal/cmd/off.go
+++ b/internal/cmd/off.go
@@ -1,43 +1,11 @@
 package cmd
 
-import (
-	"context"
-	"fmt"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
-	"github.com/steipete/eightctl/internal/client"
-)
+import "github.com/spf13/cobra"
 
 var offCmd = &cobra.Command{
 	Use:   "off",
 	Short: "Turn pod off",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireAuthFields(); err != nil {
-			return err
-		}
-		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
-		targets, targeted, err := resolveCommandTargets(context.Background(), cmd, cl)
-		if err != nil {
-			return err
-		}
-		if targeted {
-			for _, target := range targets {
-				if err := cl.TurnOffForUser(context.Background(), target.UserID); err != nil {
-					return err
-				}
-			}
-			fmt.Printf("pod turned off%s\n", targetListSuffix(targets))
-			return nil
-		}
-
-		if err := cl.TurnOffForUser(context.Background(), ""); err != nil {
-			return err
-		}
-		fmt.Printf("pod turned off\n")
-		return nil
-	},
+	RunE:  func(cmd *cobra.Command, args []string) error { return runPower(cmd, false) },
 }
 
 func init() {

--- a/internal/cmd/on.go
+++ b/internal/cmd/on.go
@@ -13,31 +13,39 @@ import (
 var onCmd = &cobra.Command{
 	Use:   "on",
 	Short: "Turn pod on",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireAuthFields(); err != nil {
-			return err
-		}
-		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
-		targets, targeted, err := resolveCommandTargets(context.Background(), cmd, cl)
-		if err != nil {
-			return err
-		}
-		if targeted {
-			for _, target := range targets {
-				if err := cl.TurnOnForUser(context.Background(), target.UserID); err != nil {
-					return err
-				}
-			}
-			fmt.Printf("pod turned on%s\n", targetListSuffix(targets))
-			return nil
-		}
+	RunE:  func(cmd *cobra.Command, args []string) error { return runPower(cmd, true) },
+}
 
-		if err := cl.TurnOnForUser(context.Background(), ""); err != nil {
-			return err
+func runPower(cmd *cobra.Command, on bool) error {
+	if err := requireAuthFields(); err != nil {
+		return err
+	}
+	cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
+	setPower := cl.TurnOffForUser
+	state := "off"
+	if on {
+		setPower = cl.TurnOnForUser
+		state = "on"
+	}
+	targets, targeted, err := resolveCommandTargets(context.Background(), cmd, cl)
+	if err != nil {
+		return err
+	}
+	if targeted {
+		for _, target := range targets {
+			if err := setPower(context.Background(), target.UserID); err != nil {
+				return err
+			}
 		}
-		fmt.Printf("pod turned on\n")
+		fmt.Printf("pod turned %s%s\n", state, targetListSuffix(targets))
 		return nil
-	},
+	}
+
+	if err := setPower(context.Background(), ""); err != nil {
+		return err
+	}
+	fmt.Printf("pod turned %s\n", state)
+	return nil
 }
 
 func init() {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -84,27 +84,10 @@ func init() {
 }
 
 func initConfig() {
-	cfg, err := config.Load(viper.GetViper(), viper.GetString("config"), viper.GetBool("config-quiet"))
+	_, err := config.Load(viper.GetViper(), viper.GetString("config"), viper.GetBool("config-quiet"))
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}
-
-	// ensure env works on the main viper, too
-	viper.SetEnvPrefix("EIGHTCTL")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
-	viper.AutomaticEnv()
-	// merge into viper defaults
-	viper.SetDefault("email", cfg.Email)
-	viper.SetDefault("password", cfg.Password)
-	viper.SetDefault("user_id", cfg.UserID)
-	viper.SetDefault("client_id", cfg.ClientID)
-	viper.SetDefault("client_secret", cfg.ClientSecret)
-	viper.SetDefault("client_id", cfg.ClientID)
-	viper.SetDefault("client_secret", cfg.ClientSecret)
-	viper.SetDefault("timezone", cfg.Timezone)
-	viper.SetDefault("output", cfg.Output)
-	viper.SetDefault("fields", cfg.Fields)
-	viper.SetDefault("verbose", cfg.Verbose)
 
 	if err := config.WarnInsecurePerms(viper.ConfigFileUsed()); err != nil {
 		logger.Warn(err.Error())

--- a/internal/cmd/sleep_range.go
+++ b/internal/cmd/sleep_range.go
@@ -75,7 +75,5 @@ var sleepRangeCmd = &cobra.Command{
 func init() {
 	sleepRangeCmd.Flags().String("from", "", "start date YYYY-MM-DD")
 	sleepRangeCmd.Flags().String("to", "", "end date YYYY-MM-DD")
-	if sleepCmd != nil {
-		sleepCmd.AddCommand(sleepRangeCmd)
-	}
+	sleepCmd.AddCommand(sleepRangeCmd)
 }

--- a/internal/cmd/util.go
+++ b/internal/cmd/util.go
@@ -1,12 +1,10 @@
 package cmd
 
-import "sort"
+import (
+	"maps"
+	"slices"
+)
 
 func mapKeys(m map[string]any) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+	return slices.Sorted(maps.Keys(m))
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -130,8 +130,7 @@ func (r *Runner) removePID() {
 	}
 }
 
-// parseTempLevel converts "68F" or "20C" to heating level approximation.
-// ParseTemp converts user input temperature string to heating level.
+// ParseTemp converts a level or an F/C temperature to a heating level approximation.
 func ParseTemp(s string) (int, error) {
 	s = strings.TrimSpace(strings.ToUpper(s))
 	if strings.HasSuffix(s, "F") {
@@ -163,23 +162,11 @@ func ParseTemp(s string) (int, error) {
 func mapFtoLevel(f float64) int {
 	// Rough map 55F -> -100, 100F -> 100.
 	scaled := (f-55)/(100-55)*200 - 100
-	if scaled < -100 {
-		scaled = -100
-	}
-	if scaled > 100 {
-		scaled = 100
-	}
-	return int(scaled)
+	return int(min(100, max(-100, scaled)))
 }
 
 func mapCtoLevel(c float64) int {
 	// 13C ~ 55F, 38C ~ 100F
 	scaled := (c-13)/(38-13)*200 - 100
-	if scaled < -100 {
-		scaled = -100
-	}
-	if scaled > 100 {
-		scaled = 100
-	}
-	return int(scaled)
+	return int(min(100, max(-100, scaled)))
 }


### PR DESCRIPTION
Remove duplicate configuration setup and default copying: config.Load already configures the same Viper instance. Share on/off target resolution and output, remove an unreachable initialization guard and redundant trimming, and use standard map/slice and min/max helpers supported by the existing Go floor. Correct the specification's stale state-sync claim; the reserved flag remains unchanged.

Validation: Go 1.26.8 `go test ./...` passed; isolated Codex autoreview was scoped-clean at P0–P2. No runtime or CLI contracts were removed.

Live proof: built the production CLI with Go 1.26.8 and CGO disabled, ran `on --help` and `off --help`, and ran `--config <synthetic.yaml> version` both with and without `--quiet`. Both print `0.2.6`; only the non-quiet invocation prints the selected config notice. No provider requests were needed.
