### PR TITLE
refactor: remove dead helpers and make retry tests deterministic

### DIFF
--- a/internal/client/eightsleep_test.go
+++ b/internal/client/eightsleep_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
 
@@ -38,16 +39,6 @@ func mockServer(t *testing.T) (*httptest.Server, *Client) {
 			return
 		}
 		http.NotFound(w, r)
-	})
-
-	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
-		// first call rate limits, second succeeds
-		if r.Header.Get("X-Test-Retry") == "done" {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"ok":true}`))
-			return
-		}
-		w.WriteHeader(http.StatusTooManyRequests)
 	})
 
 	srv := httptest.NewServer(mux)
@@ -172,35 +163,29 @@ func TestNoExplicitGzipHeader(t *testing.T) {
 }
 
 func Test429Retry(t *testing.T) {
-	count := 0
-	mux := http.NewServeMux()
-	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
-		count++
-		if count == 1 {
-			w.WriteHeader(http.StatusTooManyRequests)
-			return
+	synctest.Test(t, func(t *testing.T) {
+		count := 0
+		c := New("email", "pass", "uid", "", "")
+		c.token, c.tokenExp = "t", time.Now().Add(time.Hour)
+		c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			count++
+			code := http.StatusOK
+			if count == 1 {
+				code = http.StatusTooManyRequests
+			}
+			return &http.Response{StatusCode: code, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+		})}
+		start := time.Now()
+		if err := c.do(t.Context(), http.MethodGet, "/ping", nil, nil, nil); err != nil {
+			t.Fatalf("do retry: %v", err)
 		}
-		w.WriteHeader(http.StatusOK)
+		if count != 2 {
+			t.Fatalf("expected 2 attempts, got %d", count)
+		}
+		if elapsed := time.Since(start); elapsed != 2*time.Second {
+			t.Fatalf("backoff = %v, want 2s", elapsed)
+		}
 	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	c := New("email", "pass", "uid", "", "")
-	c.BaseURL = srv.URL
-	c.token = "t"
-	c.tokenExp = time.Now().Add(time.Hour)
-	c.HTTP = srv.Client()
-
-	start := time.Now()
-	if err := c.do(context.Background(), http.MethodGet, "/ping", nil, nil, nil); err != nil {
-		t.Fatalf("do retry: %v", err)
-	}
-	if count != 2 {
-		t.Fatalf("expected 2 attempts, got %d", count)
-	}
-	if elapsed := time.Since(start); elapsed < 2*time.Second {
-		t.Fatalf("expected backoff, got %v", elapsed)
-	}
 }
 
 func TestSetAwayMode(t *testing.T) {
@@ -297,28 +282,26 @@ func TestDeviceSides(t *testing.T) {
 }
 
 func Test429RetryCapped(t *testing.T) {
-	count := 0
-	mux := http.NewServeMux()
-	mux.HandleFunc("/always429", func(w http.ResponseWriter, r *http.Request) {
-		count++
-		w.WriteHeader(http.StatusTooManyRequests)
+	synctest.Test(t, func(t *testing.T) {
+		count := 0
+		c := New("email", "pass", "uid", "", "")
+		c.token, c.tokenExp = "t", time.Now().Add(time.Hour)
+		c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			count++
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+		})}
+		start := time.Now()
+		err := c.do(t.Context(), http.MethodGet, "/always429", nil, nil, nil)
+		if err == nil {
+			t.Fatal("expected error after exhausting retries")
+		}
+		if count != maxRetries+1 {
+			t.Fatalf("expected %d attempts, got %d", maxRetries+1, count)
+		}
+		if elapsed := time.Since(start); elapsed != 12*time.Second {
+			t.Fatalf("total backoff = %v, want 12s", elapsed)
+		}
 	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	c := New("email", "pass", "uid", "", "")
-	c.BaseURL = srv.URL
-	c.token = "t"
-	c.tokenExp = time.Now().Add(time.Hour)
-	c.HTTP = srv.Client()
-
-	err := c.do(context.Background(), http.MethodGet, "/always429", nil, nil, nil)
-	if err == nil {
-		t.Fatal("expected error after exhausting retries")
-	}
-	if count != maxRetries+1 {
-		t.Fatalf("expected %d attempts, got %d", maxRetries+1, count)
-	}
 }
 
 func TestSetTemperatureForUserUsesExplicitUserID(t *testing.T) {

--- a/internal/client/household.go
+++ b/internal/client/household.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 )
 
 type HouseholdActions struct{ c *Client }
@@ -102,32 +101,4 @@ func (h *HouseholdActions) Guests(ctx context.Context) (any, error) {
 	var res any
 	err := h.c.doApp(ctx, http.MethodGet, path, nil, nil, &res)
 	return res, err
-}
-
-func mapToValues(values map[string]string) url.Values {
-	out := make(url.Values, len(values))
-	for key, value := range values {
-		out.Set(key, value)
-	}
-	return out
-}
-
-func orderedUniqueStrings(values ...string) []string {
-	out := []string{}
-	for _, value := range values {
-		out = appendUniqueString(out, value)
-	}
-	return out
-}
-
-func appendUniqueString(existing []string, value string) []string {
-	if value == "" {
-		return existing
-	}
-	for _, current := range existing {
-		if current == value {
-			return existing
-		}
-	}
-	return append(existing, value)
 }

--- a/internal/client/main_test.go
+++ b/internal/client/main_test.go
@@ -8,19 +8,7 @@ import (
 	"github.com/steipete/eightctl/internal/tokencache"
 )
 
-// TestMain keeps this package's tests off the developer's real credential store.
-//
-// Several tests drive the full authentication path, and a successful
-// authentication caches the issued token through tokencache.Save. Without this,
-// Save reaches the default opener, which on a cgo-enabled macOS build is the
-// login Keychain: running `go test ./...` wrote entries for identities like
-// test@example.com into the developer's own Keychain and left them there. A
-// released binary is built with CGO_ENABLED=0 and cannot see the Keychain, so
-// `eightctl logout` will not clean them up either.
-//
-// Pointing both openers at in-memory stores for the whole package fixes every
-// current test and any later one that reaches the cache without having to
-// remember this.
+// Authentication writes tokens, so isolate both backends from persistent stores.
 func TestMain(m *testing.M) {
 	primary := keyring.NewArrayKeyring(nil)
 	file := keyring.NewArrayKeyring(nil)

--- a/internal/client/targets.go
+++ b/internal/client/targets.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"slices"
 	"strings"
 )
 
@@ -49,9 +51,7 @@ func (c *Client) HouseholdUserTargets(ctx context.Context) ([]HouseholdUserTarge
 		} `json:"result"`
 	}
 	path := fmt.Sprintf("/devices/%s", deviceID)
-	query := mapToValues(map[string]string{
-		"filter": "leftUserId,rightUserId,awaySides",
-	})
+	query := url.Values{"filter": {"leftUserId,rightUserId,awaySides"}}
 	if err := c.do(ctx, http.MethodGet, path, query, nil, &deviceRes); err != nil {
 		return nil, err
 	}
@@ -93,6 +93,21 @@ func (c *Client) HouseholdUserTargets(ctx context.Context) ([]HouseholdUserTarge
 		targets[0].Side = "solo"
 	}
 	return targets, nil
+}
+
+func orderedUniqueStrings(values ...string) []string {
+	out := []string{}
+	for _, value := range values {
+		out = appendUniqueString(out, value)
+	}
+	return out
+}
+
+func appendUniqueString(existing []string, value string) []string {
+	if value == "" || slices.Contains(existing, value) {
+		return existing
+	}
+	return append(existing, value)
 }
 
 // sideAssignmentsFromDevice builds a userID -> side map from the /devices payload.

--- a/internal/cmd/alarm.go
+++ b/internal/cmd/alarm.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -158,11 +157,9 @@ func init() {
 	viper.BindPFlag("no-vibration", alarmUpdateCmd.Flags().Lookup("no-vibration"))
 	viper.BindPFlag("sound", alarmUpdateCmd.Flags().Lookup("sound"))
 
-	// add subcommands
 	alarmCmd.AddCommand(alarmListCmd, alarmCreateCmd, alarmUpdateCmd, alarmDeleteCmd, alarmSnoozeCmd, alarmDismissCmd, alarmDismissAllCmd, alarmVibeCmd)
 }
 
-// snooze
 var alarmSnoozeCmd = &cobra.Command{Use: "snooze <id>", Args: cobra.ExactArgs(1), RunE: func(cmd *cobra.Command, args []string) error {
 	if err := requireAuthFields(); err != nil {
 		return err
@@ -194,21 +191,3 @@ var alarmVibeCmd = &cobra.Command{Use: "vibration-test", RunE: func(cmd *cobra.C
 	cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
 	return cl.Alarms().VibrationTest(context.Background())
 }}
-
-// parseDays convenience to support comma inputs (unused, kept for future).
-func parseDays(s string) ([]int, error) {
-	parts := strings.Split(s, ",")
-	res := make([]int, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		var v int
-		if _, err := fmt.Sscanf(p, "%d", &v); err != nil {
-			return nil, err
-		}
-		res = append(res, v)
-	}
-	return res, nil
-}

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -7,21 +7,36 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/daemon"
 )
 
 func TestParseDays(t *testing.T) {
-	got, err := parseDays("1, 2,,6")
-	if err != nil {
-		t.Fatalf("parseDays: %v", err)
-	}
-	if !reflect.DeepEqual(got, []int{1, 2, 6}) {
-		t.Fatalf("days = %#v", got)
-	}
-	if _, err := parseDays("x"); err == nil {
-		t.Fatalf("expected invalid day error")
+	for _, command := range []*cobra.Command{alarmCreateCmd, alarmUpdateCmd} {
+		t.Run(command.Name(), func(t *testing.T) {
+			flag := command.Flags().Lookup("days")
+			previous, changed := flag.Value.String(), flag.Changed
+			t.Cleanup(func() {
+				_ = flag.Value.(pflag.SliceValue).Replace(nil)
+				if previous != "[]" {
+					_ = flag.Value.Set(strings.Trim(previous, "[]"))
+				}
+				flag.Changed = changed
+			})
+			if err := command.ParseFlags([]string{"--days", "1,2,6"}); err != nil {
+				t.Fatal(err)
+			}
+			got, err := command.Flags().GetIntSlice("days")
+			if err != nil || !reflect.DeepEqual(got, []int{1, 2, 6}) {
+				t.Fatalf("days = %#v, error = %v", got, err)
+			}
+			if err := command.ParseFlags([]string{"--days", "x"}); err == nil {
+				t.Fatal("expected invalid day error")
+			}
+		})
 	}
 }
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -30,8 +30,8 @@ var statusCmd = &cobra.Command{
 		if allSides && target != nil {
 			return fmt.Errorf("use --all-sides by itself, not with --side or --target-user-id")
 		}
-		rows := []map[string]any{}
-		headers := []string{"mode", "level"}
+		var rows []map[string]any
+		var headers []string
 		if allSides {
 			targets, err := cl.HouseholdUserTargets(context.Background())
 			if err != nil {

--- a/internal/tokencache/tokencache.go
+++ b/internal/tokencache/tokencache.go
@@ -59,25 +59,18 @@ func SetOpenFileKeyringForTest(fn func() (keyring.Keyring, error)) (restore func
 }
 
 func defaultOpenKeyring() (keyring.Keyring, error) {
-	home, _ := os.UserHomeDir()
-	return keyring.Open(keyring.Config{
-		ServiceName: serviceName,
-		AllowedBackends: []keyring.BackendType{
-			keyring.KeychainBackend,
-			keyring.SecretServiceBackend,
-			keyring.WinCredBackend,
-			keyring.FileBackend,
-		},
-		FileDir:          filepath.Join(home, ".config", "eightctl", "keyring"),
-		FilePasswordFunc: filePassword,
-	})
+	return openBackends(keyring.KeychainBackend, keyring.SecretServiceBackend, keyring.WinCredBackend, keyring.FileBackend)
 }
 
 func defaultOpenFileKeyring() (keyring.Keyring, error) {
+	return openBackends(keyring.FileBackend)
+}
+
+func openBackends(backends ...keyring.BackendType) (keyring.Keyring, error) {
 	home, _ := os.UserHomeDir()
 	return keyring.Open(keyring.Config{
 		ServiceName:      serviceName,
-		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+		AllowedBackends:  backends,
 		FileDir:          filepath.Join(home, ".config", "eightctl", "keyring"),
 		FilePasswordFunc: filePassword,
 	})


### PR DESCRIPTION
Retry tests spent 14 seconds sleeping in real time. Use Go's existing synctest support to check the same retry counts and exact 2/12-second backoffs without waiting. Keep the other endpoint tests on real local HTTP servers. Replace the test-only, unused parseDays helper with coverage of the actual alarm flag parser, simplify shared keyring configuration and target helpers, and remove overwritten status values found by staticcheck.

Validation: fresh Go 1.26.8 `go test -count=1 ./...` passed; the client package completed in 0.421s versus 14.420s before. Core coverage passed at 86.3%. `golangci-lint run --enable-only govet,unused,staticcheck ./...` reports 0 issues. Final isolated Codex autoreview is scoped-clean at P0–P2.

Live proof: built the production CLI with Go 1.26.8/CGO disabled and ran `alarm create --help`, confirming the existing alarm options remain available. No public command, flag, cache format, dependency version, or runtime floor changes.
