### PR TITLE
ci: pin actions and strengthen parallel Go checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,22 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -29,12 +36,12 @@ jobs:
           fi
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9.3.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.13.2
 
-      - name: Test
-        run: go test ./...
+      - name: Test with race detection
+        run: go test -race ./...
 
       - name: Local install smoke test
         run: |
@@ -47,11 +54,6 @@ jobs:
             test "$("$INSTALL_ROOT/path with spaces/bin/eightctl" --version)" = "install-proof-$attempt"
           done
 
-      - name: Test minimum supported Go version
-        env:
-          GOTOOLCHAIN: go1.26.7
-        run: go test ./...
-
       - name: Release metadata consistency
         run: ./scripts/check-release-metadata
 
@@ -59,14 +61,7 @@ jobs:
         run: ./scripts/test-release-preflight
 
       - name: Coverage
-        run: |
-          go test \
-            -coverpkg=./internal/client,./internal/config,./internal/daemon,./internal/output,./internal/tokencache \
-            ./internal/client ./internal/config ./internal/daemon ./internal/output ./internal/tokencache \
-            -coverprofile=coverage.out
-          COVERAGE=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%", "", $3); print $3}')
-          echo "core coverage: ${COVERAGE}%"
-          awk -v coverage="$COVERAGE" 'BEGIN { exit !(coverage >= 85.0) }'
+        run: make coverage
 
       - name: Release notes smoke test
         run: |
@@ -80,7 +75,7 @@ jobs:
           fi
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.3
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: v2.18.1
@@ -94,3 +89,18 @@ jobs:
           ACTUAL=$("$BINARY" version)
           test "$ACTUAL" = "$EXPECTED"
           test "$("$BINARY" --version)" = "$EXPECTED"
+
+  compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ["1.26.7", "1.27.1"]
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go test ./...

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Go
-        uses: actions/setup-go@v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release-legacy.yml
+++ b/.github/workflows/release-legacy.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -48,7 +48,7 @@ jobs:
         run: git checkout --detach "refs/tags/${RELEASE_TAG}"
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.3
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: v2.18.1

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -19,7 +19,7 @@ jobs:
       already-published: ${{ steps.release-state.outputs.already-published }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@v1
+    uses: openclaw/release-workflows/.github/workflows/release-go-cli.yml@ea135a47fa5c597250c2b45a681969f1e556cdea # v1
     with:
       version: ${{ inputs.version }}
       repository-type: personal

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,8 @@ linters:
   default: none
   enable:
     - govet
+    - staticcheck
+    - unused
 
 issues:
   max-issues-per-linter: 0

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ can still trigger a Keychain authorization prompt when accessing cached tokens;
 this install helper does not make authenticated commands prompt-free on
 unattended hosts. Published releases use the separate signed release pipeline.
 
-CI runs formatting, lint, tests, the core-package coverage gate, and a release-artifact smoke test.
+CI runs formatting, lint (including staticcheck and unused-code checks), race-enabled tests, the core-package coverage gate, and a release-artifact smoke test. Separate jobs test the minimum Go 1.26.7 and current Go 1.27.1 toolchains without automatic toolchain upgrades.
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	charm.land/log/v2 v2.0.1
 	github.com/99designs/keyring v1.2.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	go.yaml.in/yaml/v3 v3.0.5
 )
@@ -40,7 +41,6 @@ require (
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/xo/terminfo v1.0.0 // indirect


### PR DESCRIPTION
Keep the supported Go floor and preferred toolchain, while checking Go 1.26.7 and 1.27.1 in parallel without automatic toolchain upgrades. Enable race detection, staticcheck and unused-code checks, cancel superseded CI runs, and reuse the existing Makefile coverage gate. Preserve the required lint-test name and all release/install smoke tests. Pin each action and the existing reusable release workflow to its resolved commit; no releases are triggered.

Dependency survey: all directly used Go modules, GoReleaser 2.18.1, golangci-lint 2.13.2, gofumpt 0.12.0 and pnpm 12.4.1 were current. Retain those versions; normalize pflag's direct dependency classification with go mod tidy. Newer modules shown by go list were unused graph entries or dependencies' own test dependencies. Checkout v7 resolves to v7.0.1; all selected action commits and Go 1.27.1 predate the 48-hour cutoff. No language floor bump.

Validation: tests pass on Go 1.26.7, 1.26.8 and 1.27.1; race tests and stronger lint pass; core coverage is 86.5%. Release metadata and preflight regression scripts pass. Isolated Codex autoreview is scoped-clean at P0–P2.

Live proof: production CLI built with Go 1.26.8 and CGO disabled; `--version` prints `0.2.6`, and `--help` lists the existing command surface. The CI run also retains the built GoReleaser artifact and repeated-install smoke tests.
