### PR TITLE
fix: bind options to the executing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ## Unreleased
 
+- Fixed alarm, audio, and Autopilot options being ignored when sibling commands registered flags with the same names; preserve flag, environment, and config precedence.
+
 ## 0.2.6 - 2026-09-11
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ eightctl temp -40 --side right
 
 Run `eightctl <command> --help` for flags and subcommands. The [command specification](docs/spec.md#cli-surface-implemented) covers the complete surface and current provider constraints.
 
+Options belong to the selected subcommand: for example, `eightctl alarm create --time 07:30 --days 1,2,3,4,5` and `eightctl autopilot level-suggestions --enabled=false` use the values passed to those commands.
+
 Use `eightctl away on --both` before a trip and `eightctl away off --both` to resume all household members, including when everyone is already away. If household user IDs cannot be resolved, the command reports an error.
 
 `eightctl away status` reads the cloud-reported state for all discovered household sides; use `--side` or `--target-user-id` to select one person. In contrast, `away on|off` without targeting flags changes only the authenticated user's side. The cloud is eventually consistent: readback may show the previous state after a write and does not immediately confirm that a change took effect.

--- a/internal/cmd/alarm.go
+++ b/internal/cmd/alarm.go
@@ -140,22 +140,12 @@ func init() {
 	alarmCreateCmd.Flags().Bool("disabled", false, "Create disabled")
 	alarmCreateCmd.Flags().Bool("no-vibration", false, "Disable vibration")
 	alarmCreateCmd.Flags().String("sound", "", "Sound id")
-	viper.BindPFlag("time", alarmCreateCmd.Flags().Lookup("time"))
-	viper.BindPFlag("days", alarmCreateCmd.Flags().Lookup("days"))
-	viper.BindPFlag("disabled", alarmCreateCmd.Flags().Lookup("disabled"))
-	viper.BindPFlag("no-vibration", alarmCreateCmd.Flags().Lookup("no-vibration"))
-	viper.BindPFlag("sound", alarmCreateCmd.Flags().Lookup("sound"))
 
 	alarmUpdateCmd.Flags().String("time", "", "HH:MM time")
 	alarmUpdateCmd.Flags().IntSlice("days", nil, "Comma-separated days 0=Sun..6=Sat")
 	alarmUpdateCmd.Flags().Bool("enabled", true, "Set enabled true/false")
 	alarmUpdateCmd.Flags().Bool("no-vibration", false, "Disable vibration")
 	alarmUpdateCmd.Flags().String("sound", "", "Sound id")
-	viper.BindPFlag("time", alarmUpdateCmd.Flags().Lookup("time"))
-	viper.BindPFlag("days", alarmUpdateCmd.Flags().Lookup("days"))
-	viper.BindPFlag("enabled", alarmUpdateCmd.Flags().Lookup("enabled"))
-	viper.BindPFlag("no-vibration", alarmUpdateCmd.Flags().Lookup("no-vibration"))
-	viper.BindPFlag("sound", alarmUpdateCmd.Flags().Lookup("sound"))
 
 	alarmCmd.AddCommand(alarmListCmd, alarmCreateCmd, alarmUpdateCmd, alarmDeleteCmd, alarmSnoozeCmd, alarmDismissCmd, alarmDismissAllCmd, alarmVibeCmd)
 }

--- a/internal/cmd/audio.go
+++ b/internal/cmd/audio.go
@@ -156,15 +156,10 @@ var audioFavRemoveCmd = &cobra.Command{Use: "remove", RunE: func(cmd *cobra.Comm
 
 func init() {
 	audioPlayCmd.Flags().String("track", "", "track ID to play")
-	viper.BindPFlag("track", audioPlayCmd.Flags().Lookup("track"))
 	audioSeekCmd.Flags().Int("position", 0, "position milliseconds")
-	viper.BindPFlag("position", audioSeekCmd.Flags().Lookup("position"))
 	audioVolumeCmd.Flags().Int("level", 50, "volume level 0-100")
-	viper.BindPFlag("level", audioVolumeCmd.Flags().Lookup("level"))
 	audioFavAddCmd.Flags().String("track", "", "track id")
-	viper.BindPFlag("track", audioFavAddCmd.Flags().Lookup("track"))
 	audioFavRemoveCmd.Flags().String("track", "", "track id")
-	viper.BindPFlag("track", audioFavRemoveCmd.Flags().Lookup("track"))
 
 	audioFavoritesCmd.AddCommand(audioFavListCmd, audioFavAddCmd, audioFavRemoveCmd)
 	audioCmd.AddCommand(audioTracksCmd, audioCategoriesCmd, audioStateCmd, audioPlayCmd, audioPauseCmd, audioSeekCmd, audioVolumeCmd, audioPairCmd, audioNextCmd, audioFavoritesCmd)

--- a/internal/cmd/autopilot.go
+++ b/internal/cmd/autopilot.go
@@ -52,9 +52,7 @@ func simpleAutopilot(name string, fn func(*client.Client, context.Context) (any,
 
 func init() {
 	autopilotLevelCmd.Flags().Bool("enabled", true, "enable or disable")
-	viper.BindPFlag("enabled", autopilotLevelCmd.Flags().Lookup("enabled"))
 	autopilotSnoreCmd.Flags().Bool("enabled", true, "enable or disable")
-	viper.BindPFlag("enabled", autopilotSnoreCmd.Flags().Lookup("enabled"))
 
 	autopilotCmd.AddCommand(autopilotDetailsCmd, autopilotHistoryCmd, autopilotRecapCmd, autopilotLevelCmd, autopilotSnoreCmd)
 }

--- a/internal/cmd/base.go
+++ b/internal/cmd/base.go
@@ -66,10 +66,7 @@ var baseTestCmd = &cobra.Command{Use: "test", RunE: func(cmd *cobra.Command, arg
 func init() {
 	baseAngleCmd.Flags().Int("head", 0, "head angle")
 	baseAngleCmd.Flags().Int("foot", 0, "foot angle")
-	viper.BindPFlag("head", baseAngleCmd.Flags().Lookup("head"))
-	viper.BindPFlag("foot", baseAngleCmd.Flags().Lookup("foot"))
 	basePresetRunCmd.Flags().String("name", "", "preset name")
-	viper.BindPFlag("name", basePresetRunCmd.Flags().Lookup("name"))
 
 	baseCmd.AddCommand(baseInfoCmd, baseAngleCmd, basePresetsCmd, basePresetRunCmd, baseTestCmd)
 }

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -56,9 +56,6 @@ func init() {
 	daemonCmd.Flags().Bool("dry-run", false, "log actions without executing")
 	daemonCmd.Flags().Bool("sync-state", false, "(reserved) sync device state")
 	daemonCmd.Flags().String("pid-file", "", "pid file path (default ~/.config/eightctl/daemon.pid)")
-	viper.BindPFlag("dry-run", daemonCmd.Flags().Lookup("dry-run"))
-	viper.BindPFlag("sync-state", daemonCmd.Flags().Lookup("sync-state"))
-	viper.BindPFlag("pid-file", daemonCmd.Flags().Lookup("pid-file"))
 }
 
 func readConfigSchedule() ([]byte, error) {

--- a/internal/cmd/flags_test.go
+++ b/internal/cmd/flags_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestCommandFlagOwnership(t *testing.T) {
+	cases := map[string]struct {
+		command *cobra.Command
+		args    []string
+		want    map[string]string
+	}{
+		"alarm create":         {alarmCreateCmd, []string{"alarm", "create", "--time", "07:30", "--days", "1,2", "--no-vibration", "--sound", "rain"}, map[string]string{"time": "07:30", "days": "[1 2]", "no-vibration": "true", "sound": "rain"}},
+		"alarm update":         {alarmUpdateCmd, []string{"alarm", "update", "id", "--enabled=false"}, map[string]string{"enabled": "false"}},
+		"audio play":           {audioPlayCmd, []string{"audio", "play", "--track", "rain"}, map[string]string{"track": "rain"}},
+		"audio add":            {audioFavAddCmd, []string{"audio", "favorites", "add", "--track", "rain"}, map[string]string{"track": "rain"}},
+		"audio remove":         {audioFavRemoveCmd, []string{"audio", "favorites", "remove", "--track", "rain"}, map[string]string{"track": "rain"}},
+		"autopilot level":      {autopilotLevelCmd, []string{"autopilot", "level-suggestions", "--enabled=false"}, map[string]string{"enabled": "false"}},
+		"autopilot snore":      {autopilotSnoreCmd, []string{"autopilot", "snore-mitigation", "--enabled=false"}, map[string]string{"enabled": "false"}},
+		"config fallback":      {alarmCreateCmd, []string{"alarm", "create"}, map[string]string{"time": "08:00"}},
+		"environment fallback": {alarmCreateCmd, []string{"alarm", "create"}, map[string]string{"time": "09:00"}},
+	}
+	if name := os.Getenv("EIGHTCTL_TEST_FLAG_CASE"); name != "" {
+		tc := cases[name]
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := os.WriteFile(path, []byte("time: '08:00'\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		tc.command.RunE = func(cmd *cobra.Command, args []string) error {
+			for key, want := range tc.want {
+				if got := fmt.Sprint(viper.Get(key)); got != want {
+					t.Errorf("%s = %q, want %q", key, got, want)
+				}
+			}
+			return nil
+		}
+		rootCmd.SetArgs(append(tc.args, "--config", path, "--quiet"))
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	// Fresh processes preserve real init-time bindings and isolate Cobra/Viper globals.
+	for name := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			command := exec.Command(os.Args[0], "-test.run=^TestCommandFlagOwnership$")
+			for _, variable := range os.Environ() {
+				if !strings.HasPrefix(variable, "EIGHTCTL_") {
+					command.Env = append(command.Env, variable)
+				}
+			}
+			command.Env = append(command.Env, "EIGHTCTL_TEST_FLAG_CASE="+name)
+			if name == "environment fallback" {
+				command.Env = append(command.Env, "EIGHTCTL_TIME=09:00")
+			}
+			if out, err := command.CombinedOutput(); err != nil {
+				t.Fatalf("command flags: %v\n%s", err, out)
+			}
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -32,6 +32,10 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		// A flag name belongs to the executing command, not its last registered sibling.
+		return viper.BindPFlags(cmd.LocalNonPersistentFlags())
+	}
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 
 	rootCmd.PersistentFlags().String("config", "", "config file (default ~/.config/eightctl/config.yaml)")

--- a/internal/cmd/temp_modes.go
+++ b/internal/cmd/temp_modes.go
@@ -120,8 +120,6 @@ func init() {
 	tempHotCmd.AddCommand(tempHotOnCmd, tempHotOffCmd, tempHotStatusCmd)
 	tempEventsCmd.Flags().String("from", "", "from date (YYYY-MM-DD)")
 	tempEventsCmd.Flags().String("to", "", "to date (YYYY-MM-DD)")
-	viper.BindPFlag("from", tempEventsCmd.Flags().Lookup("from"))
-	viper.BindPFlag("to", tempEventsCmd.Flags().Lookup("to"))
 
 	tempModeCmd.AddCommand(tempNapCmd, tempHotCmd, tempEventsCmd)
 }


### PR DESCRIPTION
`alarm create --time 07:30`, audio track selection, and `autopilot level-suggestions --enabled=false` could ignore their flags: initialization bound several siblings to the same global Viper key, so the last sibling won. Bind each command's local flags immediately before its handler and remove the old registration-time bindings. Preserve explicit flag > environment > config precedence.

Fresh-process regressions reproduced five affected paths on the old code (including enabled=false becoming true). They now pass, including config/environment fallback and execution with an ambient EIGHTCTL_TIME. All Go tests and stronger lint pass. The first isolated review caught environment contamination in the test; fixed it, and final Codex autoreview is scoped-clean at P0–P2.

Live proof: build the production CLI with Go 1.26.8/CGO disabled, then invoke `alarm create --time 07:30` with synthetic local configuration and credentials. It accepts the time and reports `--days required`, instead of incorrectly reporting `--time required`. This exits before any provider request.
