### PR TITLE
fix: make API retries cancellable and close responses promptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 ## Unreleased
 
 - Fixed alarm, audio, and Autopilot options being ignored when sibling commands registered flags with the same names; preserve flag, environment, and config precedence.
+- Fixed API retries delaying cancellation, retaining response bodies, and reusing rejected tokens when cache deletion fails.
 
 ## 0.2.6 - 2026-09-11
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -9,7 +9,7 @@ Eight Sleep Pod power/control + data-export CLI, written in Go. Targets macOS/Li
   - `client_id`: `0894c7f33bb94800a03f1f4df13a4f38`
   - `client_secret`: `f0954a3ed5763ba3d06834c73731a32f15f168f47d4f164751275def86db0c76`
 - Auth flow: OAuth password grant at `https://auth-api.8slp.net/v1/tokens` (form-urlencoded).
-- Throttling: 429s observed; client retries with small delay and re-auths on 401.
+- Throttling: 429s use bounded, cancellable backoff; 401s reauthenticate without reusing the rejected cached token. Responses are closed before retrying.
 
 ## Configuration & Auth
 - Config file: `~/.config/eightctl/config.yaml`; env prefix `EIGHTCTL_`; flags override env override file.

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -36,61 +36,69 @@ func (c *Client) doApp(ctx context.Context, method, path string, query url.Value
 // BaseURL-relative paths; use doURL directly for requests to other hosts
 // (e.g. the app API for away mode).
 func (c *Client) doURL(ctx context.Context, method, u string, body any, out any) error {
-	return c.doURLRetry(ctx, method, u, body, out, 0)
-}
-
-func (c *Client) doURLRetry(ctx context.Context, method, u string, body any, out any, attempt int) error {
-	if err := c.ensureToken(ctx); err != nil {
-		return err
-	}
-	var rdr io.Reader
-	if body != nil {
-		b, err := json.Marshal(body)
-		if err != nil {
+	for attempt := 0; ; attempt++ {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-		rdr = bytes.NewReader(b)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, u, rdr)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Connection", "keep-alive")
-	req.Header.Set("User-Agent", "okhttp/4.9.3")
-	// Do not set Accept-Encoding explicitly; Go handles gzip transparently.
-
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusTooManyRequests {
-		if attempt >= maxRetries {
-			return fmt.Errorf("rate limited after %d retries: %s %s", maxRetries, method, u)
-		}
-		time.Sleep(time.Duration(2*(attempt+1)) * time.Second)
-		return c.doURLRetry(ctx, method, u, body, out, attempt+1)
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if attempt >= maxRetries {
-			return fmt.Errorf("unauthorized after %d retries: %s %s", maxRetries, method, u)
-		}
-		c.token = ""
-		_ = tokencache.Clear(c.Identity())
 		if err := c.ensureToken(ctx); err != nil {
 			return err
 		}
-		return c.doURLRetry(ctx, method, u, body, out, attempt+1)
+		var rdr io.Reader
+		if body != nil {
+			b, err := json.Marshal(body)
+			if err != nil {
+				return err
+			}
+			rdr = bytes.NewReader(b)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, u, rdr)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Connection", "keep-alive")
+		req.Header.Set("User-Agent", "okhttp/4.9.3")
+		// Leave Accept-Encoding to Go so gzip responses are decoded transparently.
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			return err
+		}
+		switch resp.StatusCode {
+		case http.StatusTooManyRequests:
+			resp.Body.Close()
+			if attempt >= maxRetries {
+				return fmt.Errorf("rate limited after %d retries: %s %s", maxRetries, method, u)
+			}
+			timer := time.NewTimer(time.Duration(2*(attempt+1)) * time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		case http.StatusUnauthorized:
+			resp.Body.Close()
+			if attempt >= maxRetries {
+				return fmt.Errorf("unauthorized after %d retries: %s %s", maxRetries, method, u)
+			}
+			c.token = ""
+			_ = tokencache.Clear(c.Identity())
+			// A failed cache removal must not reload the token the server just rejected.
+			if err := c.Authenticate(ctx); err != nil {
+				return err
+			}
+		default:
+			defer resp.Body.Close()
+			if resp.StatusCode >= 300 {
+				b, _ := io.ReadAll(resp.Body)
+				return fmt.Errorf("api %s %s: %s", method, u, string(b))
+			}
+			if out != nil {
+				return json.NewDecoder(resp.Body).Decode(out)
+			}
+			return nil
+		}
 	}
-	if resp.StatusCode >= 300 {
-		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("api %s %s: %s", method, u, string(b))
-	}
-	if out != nil {
-		return json.NewDecoder(resp.Body).Decode(out)
-	}
-	return nil
 }

--- a/internal/client/transport_test.go
+++ b/internal/client/transport_test.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/99designs/keyring"
+	"github.com/steipete/eightctl/internal/tokencache"
+)
+
+func TestRetryCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		c := New("fixture", "fixture", "uid", "", "")
+		c.token, c.tokenExp = "fixture", time.Now().Add(time.Hour)
+		attempts := 0
+		c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{StatusCode: 429, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})}
+		go func() { time.Sleep(100 * time.Millisecond); cancel() }()
+		start := time.Now()
+		err := c.do(ctx, http.MethodGet, "/test", nil, nil, nil)
+		if !errors.Is(err, context.Canceled) || time.Since(start) != 100*time.Millisecond || attempts != 1 {
+			t.Fatalf("error=%v elapsed=%v attempts=%d", err, time.Since(start), attempts)
+		}
+	})
+}
+
+type trackedBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *trackedBody) Close() error { b.closed = true; return nil }
+
+func TestRetryClosesResponseAndReplaysBody(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		c := New("fixture", "fixture", "uid", "", "")
+		c.token, c.tokenExp = "fixture", time.Now().Add(time.Hour)
+		var previous *trackedBody
+		attempts := 0
+		c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if previous != nil && !previous.closed {
+				t.Error("previous response remains open during retry")
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil || string(body) != `{"level":12}` {
+				t.Fatalf("request body = %s, error = %v", body, err)
+			}
+			attempts++
+			code := http.StatusTooManyRequests
+			if attempts == 2 {
+				code = http.StatusNoContent
+			}
+			previous = &trackedBody{Reader: strings.NewReader("")}
+			return &http.Response{StatusCode: code, Body: previous}, nil
+		})}
+		if err := c.do(t.Context(), http.MethodPut, "/test", nil, map[string]int{"level": 12}, nil); err != nil {
+			t.Fatal(err)
+		}
+		if attempts != 2 || !previous.closed {
+			t.Fatalf("attempts=%d closed=%v", attempts, previous.closed)
+		}
+	})
+}
+
+type removalDeniedKeyring struct{ keyring.Keyring }
+
+func (removalDeniedKeyring) Remove(string) error { return errors.New("fixture removal denied") }
+
+func TestUnauthorizedReauthenticatesWhenCacheRemovalFails(t *testing.T) {
+	ring := removalDeniedKeyring{keyring.NewArrayKeyring(nil)}
+	t.Cleanup(tokencache.SetOpenKeyringForTest(func() (keyring.Keyring, error) { return ring, nil }))
+	t.Cleanup(tokencache.SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return ring, nil }))
+	c := New("fixture", "fixture", "uid", "", "")
+	if err := tokencache.Save(c.Identity(), "rejected", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatal(err)
+	}
+	requests, authentications := 0, 0
+	var rejected *trackedBody
+	c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() == authURL {
+			authentications++
+			if rejected != nil && !rejected.closed {
+				t.Error("401 response still open during authentication")
+			}
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"access_token":"fresh","expires_in":3600}`))}, nil
+		}
+		requests++
+		if req.Header.Get("Authorization") == "Bearer fresh" {
+			return &http.Response{StatusCode: 204, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}
+		rejected = &trackedBody{Reader: strings.NewReader("")}
+		return &http.Response{StatusCode: 401, Body: rejected}, nil
+	})}
+	if err := c.do(t.Context(), http.MethodGet, "/test", nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 || authentications != 1 {
+		t.Fatalf("requests=%d authentications=%d", requests, authentications)
+	}
+}


### PR DESCRIPTION
API retries kept response bodies open while recursively retrying, ignored cancellation during backoff, and could reload the same rejected token when a keyring refused deletion. Give one iterative loop ownership of the retry budget and response lifetime: close before retrying, wait with the request context, and authenticate directly after a 401.

All three regressions failed on the old implementation: cancellation took 12s/four attempts, the previous response was still open on retry, and failed cache deletion exhausted the unauthorized retry budget without reauthenticating. They now pass, along with existing exact backoff/count checks, client race tests, and lint. Isolated Codex autoreview is scoped-clean at P0–P2.

Live proof: built a standalone program using the production client and memory-only token stores, then called ListTracks against a local HTTP server returning 429. The context deadline cancelled the call in 102ms with exactly one request (PASS). No provider traffic or persistent credential stores were used. The source is retained in the local task report directory as transport-proof.go.
