### PR TITLE
fix: resolve cached account identity before logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ## Unreleased
 
+- Fixed logout leaving a usable cached session when email is omitted; reject ambiguous accounts without deleting tokens and recognize legacy/current keys for one account.
 - Fixed alarm, audio, and Autopilot options being ignored when sibling commands registered flags with the same names; preserve flag, environment, and config precedence.
 - Fixed API retries delaying cancellation, retaining response bodies, and reusing rejected tokens when cache deletion fails.
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ eightctl status --fields side,name,mode,level
 
 `eightctl logout` removes the selected account's local cached token from reachable stores. It returns an error if a reachable store refuses deletion, even when another store clears successfully. An unavailable store remains tolerated if another opens. Logout does not revoke tokens at Eight Sleep; an already-issued token remains valid at the service until it expires.
 
+When no email is configured, logout resolves a single cached account across reachable stores. If more than one account matches, it asks for `--email` and leaves the stores untouched. Legacy and current cache keys for the same account are removed together.
+
 The API is undocumented and cloud-only. The [project specification](docs/spec.md#reality-of-the-api) records the current contract, while [CHANGELOG.md](CHANGELOG.md) tracks endpoint removals and compatibility changes.
 
 ## Development

--- a/internal/tokencache/identity_test.go
+++ b/internal/tokencache/identity_test.go
@@ -1,0 +1,85 @@
+package tokencache
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/99designs/keyring"
+)
+
+func TestClearWithoutEmailRemovesSelectedAccount(t *testing.T) {
+	primary, fallback := keyring.NewArrayKeyring(nil), keyring.NewArrayKeyring(nil)
+	t.Cleanup(SetOpenKeyringForTest(func() (keyring.Keyring, error) { return primary, nil }))
+	t.Cleanup(SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return fallback, nil }))
+	id := Identity{BaseURL: "https://fixture.invalid", ClientID: "fixture", Email: "user@example.invalid"}
+	if err := Save(id, "fixture", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatal(err)
+	}
+	withoutEmail := id
+	withoutEmail.Email = ""
+	if _, err := Load(withoutEmail); err != nil {
+		t.Fatal(err)
+	}
+	if err := Clear(withoutEmail); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(id); err == nil {
+		t.Fatal("logout left the selected account usable")
+	}
+}
+
+func TestClearWithoutEmailRejectsAmbiguityAcrossStores(t *testing.T) {
+	primary, fallback := keyring.NewArrayKeyring(nil), keyring.NewArrayKeyring(nil)
+	t.Cleanup(SetOpenKeyringForTest(func() (keyring.Keyring, error) { return primary, nil }))
+	t.Cleanup(SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return fallback, nil }))
+	id := Identity{BaseURL: "https://fixture.invalid", ClientID: "fixture"}
+	for i, ring := range []keyring.Keyring{primary, fallback} {
+		account := id
+		account.Email = []string{"one@example.invalid", "two@example.invalid"}[i]
+		if err := ring.Set(keyring.Item{Key: storageKey(account), Data: []byte("fixture")}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := Clear(id); err == nil {
+		t.Fatal("ambiguous logout reported success")
+	}
+	for _, ring := range []keyring.Keyring{primary, fallback} {
+		keys, err := ring.Keys()
+		if err != nil || len(keys) != 1 {
+			t.Fatalf("ambiguous logout changed a store: %v %v", keys, err)
+		}
+	}
+}
+
+func TestLegacyAndCurrentKeysAreOneAccount(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	t.Cleanup(SetOpenKeyringForTest(func() (keyring.Keyring, error) { return ring, nil }))
+	t.Cleanup(SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return ring, nil }))
+	id := Identity{BaseURL: "https://fixture.invalid", ClientID: "fixture", Email: "user@example.invalid"}
+	if err := Save(id, "current", time.Now().Add(time.Hour), "uid"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(CachedToken{Token: "legacy", ExpiresAt: time.Now().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ring.Set(keyring.Item{Key: cacheKey(id), Data: data}); err != nil {
+		t.Fatal(err)
+	}
+	id.Email = ""
+	got, err := Load(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Token != "current" {
+		t.Fatal("did not prefer current cache key")
+	}
+	if err := Clear(id); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := ring.Keys()
+	if err != nil || len(keys) != 0 {
+		t.Fatalf("logout left keys: %v %v", keys, err)
+	}
+}

--- a/internal/tokencache/tokencache.go
+++ b/internal/tokencache/tokencache.go
@@ -185,36 +185,53 @@ func loadFrom(opener func() (keyring.Keyring, error), id Identity) (*CachedToken
 // An unavailable backend is tolerated if another opens, but removal failures
 // from an opened backend are returned. This does not revoke tokens at the service.
 func Clear(id Identity) error {
-	primaryOpened, primaryErr := clearFrom(openKeyring, id)
-	fileOpened, fileErr := clearFrom(openFileKeyring, id)
-
-	if primaryOpened && primaryErr != nil {
-		return primaryErr
-	}
-	if fileOpened && fileErr != nil {
-		return fileErr
-	}
-	if !primaryOpened && !fileOpened {
-		return primaryErr
-	}
-	return nil
-}
-
-// clearFrom distinguishes an unavailable backend from an incomplete removal.
-func clearFrom(opener func() (keyring.Keyring, error), id Identity) (opened bool, err error) {
-	ring, err := opener()
-	if err != nil {
-		return false, err
-	}
-	for i, key := range []string{storageKey(id), cacheKey(id)} {
-		if err := ring.Remove(key); err != nil {
-			if isAbsentOrUnnameable(err, i == 1) {
-				continue
-			}
-			return true, err
+	var rings []keyring.Keyring
+	var openErrors []error
+	for _, opener := range []func() (keyring.Keyring, error){openKeyring, openFileKeyring} {
+		ring, err := opener()
+		if err != nil {
+			openErrors = append(openErrors, err)
+		} else {
+			rings = append(rings, ring)
 		}
 	}
-	return true, nil
+	if len(rings) == 0 {
+		return errors.Join(openErrors...)
+	}
+	if strings.TrimSpace(id.Email) == "" {
+		identities := map[string]struct{}{}
+		for _, ring := range rings {
+			matches, err := keysForClient(ring, id)
+			if err != nil {
+				return err
+			}
+			for identity := range matches {
+				identities[identity] = struct{}{}
+			}
+		}
+		if len(identities) > 1 {
+			return errors.New("multiple cached accounts; specify --email to log out")
+		}
+		for identity := range identities {
+			id.Email = strings.TrimPrefix(identity, clientKeyPrefix(id))
+		}
+	}
+	var removalErrors []error
+	for _, ring := range rings {
+		if err := clearFrom(ring, id); err != nil {
+			removalErrors = append(removalErrors, err)
+		}
+	}
+	return errors.Join(removalErrors...)
+}
+
+func clearFrom(ring keyring.Keyring, id Identity) error {
+	for i, key := range []string{storageKey(id), cacheKey(id)} {
+		if err := ring.Remove(key); err != nil && !isAbsentOrUnnameable(err, i == 1) {
+			return err
+		}
+	}
+	return nil
 }
 
 func isAbsentOrUnnameable(err error, legacy bool) bool {
@@ -266,20 +283,39 @@ func isIgnorableLegacyKeyError(err error) bool {
 // findSingleForClient finds a single cached key for the given base/client when email is unknown.
 // Returns ErrKeyNotFound if none or multiple exist.
 func findSingleForClient(ring keyring.Keyring, id Identity) (string, error) {
-	keys, err := ring.Keys()
+	matches, err := keysForClient(ring, id)
 	if err != nil {
 		return "", err
 	}
-	prefix := tokenKey + ":" + strings.TrimSuffix(strings.ToLower(strings.TrimSpace(id.BaseURL)), "/") + "|" + id.ClientID + "|"
-	matches := []string{}
-	for _, k := range keys {
-		identityKey, ok := identityKeyFromStorageKey(k)
-		if ok && strings.HasPrefix(identityKey, prefix) {
-			matches = append(matches, k)
+	if len(matches) == 1 {
+		for _, key := range matches {
+			return key, nil
 		}
 	}
-	if len(matches) == 1 {
-		return matches[0], nil
-	}
 	return "", keyring.ErrKeyNotFound
+}
+
+func clientKeyPrefix(id Identity) string {
+	id.Email = ""
+	return cacheKey(id)
+}
+
+// Group legacy and current storage keys by account, preferring the current key.
+func keysForClient(ring keyring.Keyring, id Identity) (map[string]string, error) {
+	keys, err := ring.Keys()
+	if err != nil {
+		return nil, err
+	}
+	matches := map[string]string{}
+	prefix := clientKeyPrefix(id)
+	for _, key := range keys {
+		identity, ok := identityKeyFromStorageKey(key)
+		if !ok || !strings.HasPrefix(identity, prefix) {
+			continue
+		}
+		if _, exists := matches[identity]; !exists || strings.HasPrefix(key, storageKeyV2Prefix) {
+			matches[identity] = key
+		}
+	}
+	return matches, nil
 }


### PR DESCRIPTION
A cached session could authenticate without an email, but logout removed only empty-email keys and reported success while the real account token survived. Resolve one cached identity across reachable stores before deletion; reject multiple accounts or listing errors without modifying stores. Remove both legacy/current keys for the selected identity, and treat those key formats as one account during wildcard lookup.

Regression tests reproduced the surviving session, silent ambiguous logout, and duplicate-key lookup failure on the old code. Tests and lint pass; core coverage is 86.9%. Isolated Codex autoreview is scoped-clean at P0–P2. Explicit-email cleanup and existing partial-failure handling remain intact.

Live proof: built a standalone program using the production token-cache package and a real isolated file keyring. It saved a synthetic named-account token, loaded it without an email, logged out without an email, verified named lookup now fails, and confirmed zero cache files remained (PASS). Proof source retained as cache-proof.go in the local report directory.
