### PR TITLE
fix: validate configuration and temperature input before commands run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 ## Unreleased
 
 - Fixed logout leaving a usable cached session when email is omitted; reject ambiguous accounts without deleting tokens and recognize legacy/current keys for one account.
+- Fixed `temp` ignoring persistent flags and requiring credentials for help; reject malformed temperatures and report explicit missing or malformed config files before commands run.
 - Fixed alarm, audio, and Autopilot options being ignored when sibling commands registered flags with the same names; preserve flag, environment, and config precedence.
 - Fixed API retries delaying cancellation, retaining response bodies, and reusing rejected tokens when cache deletion fails.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Keep the file readable only by your account with `chmod 600 ~/.config/eightctl/c
 
 Schedule times and dates use the configured `timezone`, even when it differs from the host timezone.
 
+An absent default config file is optional. An explicitly selected missing file or malformed YAML is an error. Temperature values must be complete integer levels from -100 to 100, or finite numbers ending in `F` or `C`; persistent flags also work after `temp`, including with negative values.
+
 Preview scheduled actions without changing the pod, then remove `--dry-run` when the schedule is ready:
 
 ```sh

--- a/internal/cmd/flags_test.go
+++ b/internal/cmd/flags_test.go
@@ -26,6 +26,7 @@ func TestCommandFlagOwnership(t *testing.T) {
 		"autopilot level":      {autopilotLevelCmd, []string{"autopilot", "level-suggestions", "--enabled=false"}, map[string]string{"enabled": "false"}},
 		"autopilot snore":      {autopilotSnoreCmd, []string{"autopilot", "snore-mitigation", "--enabled=false"}, map[string]string{"enabled": "false"}},
 		"config fallback":      {alarmCreateCmd, []string{"alarm", "create"}, map[string]string{"time": "08:00"}},
+		"temp global flags":    {tempCmd, []string{"temp", "-40", "--side", "right", "--user-id", "selected", "--timezone", "UTC"}, map[string]string{"side": "right", "user_id": "selected", "timezone": "UTC"}},
 		"environment fallback": {alarmCreateCmd, []string{"alarm", "create"}, map[string]string{"time": "09:00"}},
 	}
 	if name := os.Getenv("EIGHTCTL_TEST_FLAG_CASE"); name != "" {

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -107,7 +107,9 @@ func TestDaemonConfigFlagUsesLoadedFile(t *testing.T) {
 		t.Fatalf("bind --config: %v", err)
 	}
 
-	initConfig()
+	if err := initConfig(); err != nil {
+		t.Fatal(err)
+	}
 	if got := viper.ConfigFileUsed(); got != path {
 		t.Fatalf("ConfigFileUsed = %q, want %q", got, path)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -31,10 +31,20 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if cmd == tempCmd {
+			if err := parseTemperatureFlags(cmd, args); err != nil {
+				return err
+			}
+			if help, _ := cmd.Flags().GetBool("help"); help {
+				return nil
+			}
+		}
 		// A flag name belongs to the executing command, not its last registered sibling.
-		return viper.BindPFlags(cmd.LocalNonPersistentFlags())
+		if err := viper.BindPFlags(cmd.LocalNonPersistentFlags()); err != nil {
+			return err
+		}
+		return initConfig()
 	}
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 
@@ -87,10 +97,10 @@ func init() {
 	rootCmd.AddCommand(logoutCmd)
 }
 
-func initConfig() {
+func initConfig() error {
 	_, err := config.Load(viper.GetViper(), viper.GetString("config"), viper.GetBool("config-quiet"))
 	if err != nil {
-		log.Fatalf("config: %v", err)
+		return fmt.Errorf("config: %w", err)
 	}
 
 	if err := config.WarnInsecurePerms(viper.ConfigFileUsed()); err != nil {
@@ -100,6 +110,7 @@ func initConfig() {
 	if viper.GetBool("verbose") {
 		log.SetLevel(log.DebugLevel)
 	}
+	return nil
 }
 
 func requireAuthFields() error {

--- a/internal/cmd/temp.go
+++ b/internal/cmd/temp.go
@@ -17,20 +17,18 @@ var tempCmd = &cobra.Command{
 	Short:              "Set pod temperature (e.g., 68F, 20C, or heating level -100..100)",
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if help, _ := cmd.Flags().GetBool("help"); help {
+			return cmd.Help()
+		}
+		lvl, err := daemon.ParseTemp(cmd.Flags().Arg(0))
+		if err != nil {
+			return err
+		}
 		if err := requireAuthFields(); err != nil {
 			return err
 		}
-		tempValue, targetUserID, side, help, err := parseTempCommandArgs(args)
-		if err != nil {
-			return err
-		}
-		if help {
-			return cmd.Help()
-		}
-		lvl, err := daemon.ParseTemp(tempValue)
-		if err != nil {
-			return err
-		}
+		targetUserID, _ := cmd.Flags().GetString("target-user-id")
+		side, _ := cmd.Flags().GetString("side")
 		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
 		targets, targeted, err := resolveCommandTargetValues(context.Background(), cl, targetUserID, side)
 		if err != nil {
@@ -58,51 +56,42 @@ func init() {
 	addTargetingFlags(tempCmd, true)
 }
 
-func parseTempCommandArgs(args []string) (tempValue string, targetUserID string, side string, help bool, err error) {
+// Move positional temperatures after -- while preserving option values, so pflag
+// can parse inherited flags without mistaking a negative temperature for a flag.
+func parseTemperatureFlags(cmd *cobra.Command, args []string) error {
+	cmd.Flags().AddFlagSet(cmd.InheritedFlags())
+	cmd.InitDefaultHelpFlag()
+	var options, values []string
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		switch {
-		case arg == "-h" || arg == "--help":
-			return "", "", "", true, nil
-		case arg == "--side":
-			i++
-			if i >= len(args) {
-				return "", "", "", false, fmt.Errorf("flag needs an argument: --side")
+		if arg == "--" {
+			values = append(values, args[i+1:]...)
+			break
+		}
+		if strings.HasPrefix(arg, "-") && !isNegativeTempCandidate(arg) {
+			options = append(options, arg)
+			if name, _, hasValue := strings.Cut(strings.TrimPrefix(arg, "--"), "="); strings.HasPrefix(arg, "--") && !hasValue {
+				flag := cmd.Flags().Lookup(name)
+				if flag != nil && flag.NoOptDefVal == "" && i+1 < len(args) {
+					i++
+					options = append(options, args[i])
+				}
 			}
-			side = args[i]
-		case strings.HasPrefix(arg, "--side="):
-			side = strings.TrimPrefix(arg, "--side=")
-		case arg == "--target-user-id":
-			i++
-			if i >= len(args) {
-				return "", "", "", false, fmt.Errorf("flag needs an argument: --target-user-id")
-			}
-			targetUserID = args[i]
-		case strings.HasPrefix(arg, "--target-user-id="):
-			targetUserID = strings.TrimPrefix(arg, "--target-user-id=")
-		case arg == "--":
-			if i+1 >= len(args) {
-				return "", "", "", false, fmt.Errorf("requires exactly 1 temperature value")
-			}
-			if tempValue != "" || len(args[i+1:]) != 1 {
-				return "", "", "", false, fmt.Errorf("requires exactly 1 temperature value")
-			}
-			tempValue = args[i+1]
-			i = len(args)
-		case strings.HasPrefix(arg, "-") && !isNegativeTempCandidate(arg):
-			return "", "", "", false, fmt.Errorf("unknown flag: %s", arg)
-		default:
-			if tempValue != "" {
-				return "", "", "", false, fmt.Errorf("requires exactly 1 temperature value")
-			}
-			tempValue = arg
+		} else {
+			values = append(values, arg)
 		}
 	}
-
-	if tempValue == "" {
-		return "", "", "", false, fmt.Errorf("requires exactly 1 temperature value")
+	options = append(options, "--")
+	if err := cmd.Flags().Parse(append(options, values...)); err != nil {
+		return err
 	}
-	return tempValue, targetUserID, side, false, nil
+	if help, _ := cmd.Flags().GetBool("help"); help {
+		return nil
+	}
+	if cmd.Flags().NArg() != 1 {
+		return fmt.Errorf("requires exactly 1 temperature value")
+	}
+	return nil
 }
 
 func isNegativeTempCandidate(arg string) bool {

--- a/internal/cmd/temp_test.go
+++ b/internal/cmd/temp_test.go
@@ -1,6 +1,42 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func parseTempCommandArgs(args []string) (value, userID, side string, help bool, err error) {
+	command := &cobra.Command{Use: "temp"}
+	addTargetingFlags(command, true)
+	err = parseTemperatureFlags(command, args)
+	value = command.Flags().Arg(0)
+	userID, _ = command.Flags().GetString("target-user-id")
+	side, _ = command.Flags().GetString("side")
+	help, _ = command.Flags().GetBool("help")
+	return
+}
+
+func TestTemperatureParsesInheritedFlags(t *testing.T) {
+	root := &cobra.Command{Use: "eightctl"}
+	root.PersistentFlags().String("config", "", "")
+	root.PersistentFlags().String("password", "", "")
+	command := &cobra.Command{Use: "temp"}
+	addTargetingFlags(command, true)
+	root.AddCommand(command)
+	if err := parseTemperatureFlags(command, []string{"-40", "--config", "settings.yaml", "--password", "-123", "--side", "right"}); err != nil {
+		t.Fatal(err)
+	}
+	if command.Flags().Arg(0) != "-40" {
+		t.Fatal("negative temperature lost")
+	}
+	if got, _ := command.Flags().GetString("password"); got != "-123" {
+		t.Fatalf("password = %q", got)
+	}
+	if got, _ := command.Flags().GetString("config"); got != "settings.yaml" {
+		t.Fatalf("config = %q", got)
+	}
+}
 
 func TestParseTempCommandArgsAllowsNegativeLevelBeforeFlags(t *testing.T) {
 	tempValue, targetUserID, side, help, err := parseTempCommandArgs([]string{"-40", "--side", "right"})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,7 +45,12 @@ func Load(v *viper.Viper, configPath string, quiet bool) (Config, error) {
 	v.SetDefault("timezone", "local")
 	v.SetDefault("output", "table")
 
-	if err := v.ReadInConfig(); err == nil {
+	if err := v.ReadInConfig(); err != nil {
+		var notFound viper.ConfigFileNotFoundError
+		if configPath != "" || !errors.As(err, &notFound) {
+			return Config{}, fmt.Errorf("read config: %w", err)
+		}
+	} else {
 		if !quiet {
 			fmt.Fprintf(os.Stderr, "Using config file: %s\n", v.ConfigFileUsed())
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,26 @@ func TestLoadDefaultsWhenConfigMissing(t *testing.T) {
 	}
 }
 
+func TestLoadReportsFileErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := Load(viper.New(), filepath.Join(t.TempDir(), "missing.yaml"), true); err == nil {
+		t.Error("explicit missing config was ignored")
+	}
+	dir := filepath.Join(os.Getenv("HOME"), ".config", "eightctl")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("schedule: ["), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, selected := range []string{path, ""} {
+		if _, err := Load(viper.New(), selected, true); err == nil {
+			t.Errorf("malformed config %q was ignored", selected)
+		}
+	}
+}
+
 func TestWarnInsecurePerms(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(path, []byte("email: x"), 0o644); err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,9 +3,11 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -133,29 +135,24 @@ func (r *Runner) removePID() {
 // ParseTemp converts a level or an F/C temperature to a heating level approximation.
 func ParseTemp(s string) (int, error) {
 	s = strings.TrimSpace(strings.ToUpper(s))
-	if strings.HasSuffix(s, "F") {
-		v := strings.TrimSuffix(s, "F")
-		var f float64
-		_, err := fmt.Sscanf(v, "%f", &f)
-		if err != nil {
-			return 0, err
+	if strings.HasSuffix(s, "F") || strings.HasSuffix(s, "C") {
+		value, err := strconv.ParseFloat(strings.TrimSpace(s[:len(s)-1]), 64)
+		if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+			return 0, fmt.Errorf("temperature must be a finite number followed by F or C")
 		}
-		return mapFtoLevel(f), nil
-	}
-	if strings.HasSuffix(s, "C") {
-		v := strings.TrimSuffix(s, "C")
-		var c float64
-		_, err := fmt.Sscanf(v, "%f", &c)
-		if err != nil {
-			return 0, err
+		if strings.HasSuffix(s, "F") {
+			return mapFtoLevel(value), nil
 		}
-		return mapCtoLevel(c), nil
+		return mapCtoLevel(value), nil
 	}
-	var lvl int
-	if _, err := fmt.Sscanf(s, "%d", &lvl); err == nil {
-		return lvl, nil
+	level, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("temperature must end with F/C or be an integer level")
 	}
-	return 0, fmt.Errorf("temperature must end with F/C or be level")
+	if level < -100 || level > 100 {
+		return 0, fmt.Errorf("level must be between -100 and 100")
+	}
+	return level, nil
 }
 
 // Simple linear approximations; Eight Sleep internals are non-linear, but this keeps UX consistent.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -38,6 +38,14 @@ func TestParseTemp(t *testing.T) {
 	}
 }
 
+func TestParseTempRejectsMalformedValues(t *testing.T) {
+	for _, value := range []string{"20junk", "20.5", "20oopsC", "68oopsF", "NaNF", "+InfC", "-InfF", "101", "-101", ""} {
+		if level, err := ParseTemp(value); err == nil {
+			t.Errorf("ParseTemp(%q) = %d without an error", value, level)
+		}
+	}
+}
+
 func TestRunnerProcessExecutesDueItemsOnce(t *testing.T) {
 	useTempKeyring(t)
 	var requests []string


### PR DESCRIPTION
Negative temperature support disabled Cobra parsing entirely, so `temp` ignored persistent flags and checked credentials before help. Normalize negative positional values for pflag and parse inherited flags before loading configuration or authenticating. Keep existing negative/side syntax, and allow credential-free help.

Also stop silently ignoring missing explicitly selected or malformed config files, and replace prefix-based temperature scanning with complete integer/finite-number parsing. Preserve F/C clamping and the -100..100 level range.

Regressions reproduced ignored config errors and accepted values such as `20junk`, `20.5`, `NaNF`, and infinities. The suite and lint pass, core coverage is 86.7%, and isolated Codex autoreview is scoped-clean at P0–P2. Existing argument tests remain, with added inherited-flag and negative option-value coverage.

Live production CLI proof: `temp --help` succeeds without credentials; `temp 20junk --config <synthetic.yaml>` rejects the malformed value; `temp -40 --config <malformed.yaml>` reports the config error; and `version --config <missing.yaml>` returns an error. All checks passed without provider traffic.
