### PR TITLE
fix: apply output field selection to rows and headers together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 - Fixed logout leaving a usable cached session when email is omitted; reject ambiguous accounts without deleting tokens and recognize legacy/current keys for one account.
 - Fixed `temp` ignoring persistent flags and requiring credentials for help; reject malformed temperatures and report explicit missing or malformed config files before commands run.
+- Fixed `--fields` leaving unselected columns and `<nil>` cells in table/CSV output; apply the same field selection to all row-producing commands.
 - Fixed alarm, audio, and Autopilot options being ignored when sibling commands registered flags with the same names; preserve flag, environment, and config precedence.
 - Fixed API retries delaying cancellation, retaining response bodies, and reusing rejected tokens when cache deletion fails.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ eightctl daemon --config ~/.config/eightctl/config.yaml --dry-run
 
 Commands that return rows support table, JSON, and CSV output. Use `--fields` to select columns:
 
+Selected fields also define column order in table and CSV output. For commands returning a nested payload, selection applies to the top-level row fields.
+
 ```sh
 eightctl status --output json
 eightctl sleep day --date 2026-08-01 --output csv

--- a/internal/cmd/alarm.go
+++ b/internal/cmd/alarm.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var alarmCmd = &cobra.Command{
@@ -39,8 +38,7 @@ var alarmListCmd = &cobra.Command{
 				"sound":     a.Sound,
 			})
 		}
-		rows = output.FilterFields(rows, viper.GetStringSlice("fields"))
-		return output.Print(output.Format(viper.GetString("output")), []string{"id", "time", "enabled", "days", "vibration", "sound"}, rows)
+		return printRows([]string{"id", "time", "enabled", "days", "vibration", "sound"}, rows)
 	},
 }
 

--- a/internal/cmd/audio.go
+++ b/internal/cmd/audio.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var audioCmd = &cobra.Command{Use: "audio", Short: "Audio tracks and player"}
@@ -26,12 +25,7 @@ var audioTracksCmd = &cobra.Command{Use: "tracks", RunE: func(cmd *cobra.Command
 	for _, t := range tracks {
 		rows = append(rows, map[string]any{"id": t.ID, "title": t.Title, "type": t.Type})
 	}
-	rows = output.FilterFields(rows, viper.GetStringSlice("fields"))
-	headers := viper.GetStringSlice("fields")
-	if len(headers) == 0 {
-		headers = []string{"id", "title", "type"}
-	}
-	return output.Print(output.Format(viper.GetString("output")), headers, rows)
+	return printRows([]string{"id", "title", "type"}, rows)
 }}
 
 var audioCategoriesCmd = &cobra.Command{Use: "categories", RunE: func(cmd *cobra.Command, args []string) error {
@@ -44,7 +38,7 @@ var audioCategoriesCmd = &cobra.Command{Use: "categories", RunE: func(cmd *cobra
 		return err
 	}
 	rows := []map[string]any{{"data": res}}
-	return output.Print(output.Format(viper.GetString("output")), []string{"data"}, rows)
+	return printRows([]string{"data"}, rows)
 }}
 
 var audioStateCmd = &cobra.Command{Use: "state", RunE: func(cmd *cobra.Command, args []string) error {
@@ -57,7 +51,7 @@ var audioStateCmd = &cobra.Command{Use: "state", RunE: func(cmd *cobra.Command, 
 		return err
 	}
 	rows := []map[string]any{{"state": res}}
-	return output.Print(output.Format(viper.GetString("output")), []string{"state"}, rows)
+	return printRows([]string{"state"}, rows)
 }}
 
 var audioPlayCmd = &cobra.Command{Use: "play", RunE: func(cmd *cobra.Command, args []string) error {
@@ -113,7 +107,7 @@ var audioNextCmd = &cobra.Command{Use: "next", RunE: func(cmd *cobra.Command, ar
 		return err
 	}
 	rows := []map[string]any{{"next": res}}
-	return output.Print(output.Format(viper.GetString("output")), []string{"next"}, rows)
+	return printRows([]string{"next"}, rows)
 }}
 
 var audioFavoritesCmd = &cobra.Command{Use: "favorites", Short: "Favorite tracks"}
@@ -127,7 +121,7 @@ var audioFavListCmd = &cobra.Command{Use: "list", RunE: func(cmd *cobra.Command,
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"favorites"}, []map[string]any{{"favorites": res}})
+	return printRows([]string{"favorites"}, []map[string]any{{"favorites": res}})
 }}
 
 var audioFavAddCmd = &cobra.Command{Use: "add", RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/autopilot.go
+++ b/internal/cmd/autopilot.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var autopilotCmd = &cobra.Command{Use: "autopilot", Short: "Autopilot settings"}
@@ -46,7 +45,7 @@ func simpleAutopilot(name string, fn func(*client.Client, context.Context) (any,
 		if err != nil {
 			return err
 		}
-		return output.Print(output.Format(viper.GetString("output")), []string{name}, []map[string]any{{name: res}})
+		return printRows([]string{name}, []map[string]any{{name: res}})
 	}}
 }
 

--- a/internal/cmd/away.go
+++ b/internal/cmd/away.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var awayCmd = &cobra.Command{
@@ -97,13 +96,7 @@ func runAwayStatusWithClient(ctx context.Context, cmd *cobra.Command, cl *client
 		})
 	}
 
-	headers := []string{"side", "name", "user_id", "away"}
-	fields := viper.GetStringSlice("fields")
-	rows = output.FilterFields(rows, fields)
-	if len(fields) > 0 {
-		headers = fields
-	}
-	return output.Print(output.Format(viper.GetString("output")), headers, rows)
+	return printRows([]string{"side", "name", "user_id", "away"}, rows)
 }
 
 func runAway(cmd *cobra.Command, on bool) error {

--- a/internal/cmd/base.go
+++ b/internal/cmd/base.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var baseCmd = &cobra.Command{Use: "base", Short: "Adjustable base controls"}
@@ -21,7 +20,7 @@ var baseInfoCmd = &cobra.Command{Use: "info", RunE: func(cmd *cobra.Command, arg
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"info"}, []map[string]any{{"info": res}})
+	return printRows([]string{"info"}, []map[string]any{{"info": res}})
 }}
 
 var baseAngleCmd = &cobra.Command{Use: "angle", RunE: func(cmd *cobra.Command, args []string) error {
@@ -43,7 +42,7 @@ var basePresetsCmd = &cobra.Command{Use: "presets", RunE: func(cmd *cobra.Comman
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"presets"}, []map[string]any{{"presets": res}})
+	return printRows([]string{"presets"}, []map[string]any{{"presets": res}})
 }}
 
 var basePresetRunCmd = &cobra.Command{Use: "preset-run", RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/device.go
+++ b/internal/cmd/device.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var deviceCmd = &cobra.Command{Use: "device", Short: "Device info and priming"}
@@ -21,7 +20,7 @@ func deviceSimple(name string, fn func(ctx context.Context) (any, error)) *cobra
 		if err != nil {
 			return err
 		}
-		return output.Print(output.Format(viper.GetString("output")), []string{name}, []map[string]any{{name: res}})
+		return printRows([]string{name}, []map[string]any{{name: res}})
 	}}
 }
 

--- a/internal/cmd/feats.go
+++ b/internal/cmd/feats.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var featsCmd = &cobra.Command{
@@ -26,7 +25,6 @@ var featsCmd = &cobra.Command{
 		for _, f := range feats {
 			rows = append(rows, map[string]any{"title": f.Title, "body": f.Body})
 		}
-		rows = output.FilterFields(rows, viper.GetStringSlice("fields"))
-		return output.Print(output.Format(viper.GetString("output")), []string{"title", "body"}, rows)
+		return printRows([]string{"title", "body"}, rows)
 	},
 }

--- a/internal/cmd/household.go
+++ b/internal/cmd/household.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var householdCmd = &cobra.Command{Use: "household", Short: "Household info"}
@@ -22,7 +21,7 @@ func householdSimple(name string, fn func(*client.Client, context.Context) (any,
 		if err != nil {
 			return err
 		}
-		return output.Print(output.Format(viper.GetString("output")), []string{name}, []map[string]any{{name: res}})
+		return printRows([]string{name}, []map[string]any{{name: res}})
 	}}
 }
 

--- a/internal/cmd/metrics.go
+++ b/internal/cmd/metrics.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var metricsCmd = &cobra.Command{
@@ -40,7 +39,7 @@ var metricsTrendsCmd = &cobra.Command{Use: "trends", RunE: func(cmd *cobra.Comma
 	if err := cl.Metrics().Trends(context.Background(), from, to, tz, &out); err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"trends"}, []map[string]any{{"trends": out}})
+	return printRows([]string{"trends"}, []map[string]any{{"trends": out}})
 }}
 
 var metricsIntervalsCmd = &cobra.Command{Use: "intervals", RunE: func(cmd *cobra.Command, args []string) error {
@@ -56,7 +55,7 @@ var metricsIntervalsCmd = &cobra.Command{Use: "intervals", RunE: func(cmd *cobra
 	if err := cl.Metrics().Intervals(context.Background(), id, &out); err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"interval"}, []map[string]any{{"interval": out}})
+	return printRows([]string{"interval"}, []map[string]any{{"interval": out}})
 }}
 
 func init() {

--- a/internal/cmd/output.go
+++ b/internal/cmd/output.go
@@ -1,0 +1,10 @@
+package cmd
+
+import (
+	"github.com/spf13/viper"
+	"github.com/steipete/eightctl/internal/output"
+)
+
+func printRows(headers []string, rows []map[string]any) error {
+	return output.PrintFields(output.Format(viper.GetString("output")), headers, rows, viper.GetStringSlice("fields"))
+}

--- a/internal/cmd/output_test.go
+++ b/internal/cmd/output_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestSelectedOutputFields(t *testing.T) {
+	for _, format := range []string{"table", "csv", "json"} {
+		t.Run(format, func(t *testing.T) {
+			resetViper(t)
+			t.Cleanup(viper.Reset)
+			viper.Set("output", format)
+			viper.Set("fields", []string{"score", "date"})
+			text, err := captureAwayStatus(t, func() error {
+				return printRows([]string{"date", "score", "duration"}, []map[string]any{{"date": "2026-09-12", "score": 88, "duration": 3600}})
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(text, "duration") || strings.Contains(text, "<nil>") {
+				t.Fatalf("unselected field leaked: %s", text)
+			}
+			switch format {
+			case "csv":
+				if text != "score,date\n88,2026-09-12\n" {
+					t.Fatalf("CSV = %q", text)
+				}
+			case "table":
+				if got := strings.Fields(text); strings.Join(got, ",") != "score,date,88,2026-09-12" {
+					t.Fatalf("table = %q", text)
+				}
+			case "json":
+				var rows []map[string]any
+				if err := json.Unmarshal([]byte(text), &rows); err != nil {
+					t.Fatal(err)
+				}
+				if len(rows) != 1 || len(rows[0]) != 2 || rows[0]["score"] != float64(88) {
+					t.Fatalf("JSON = %s", text)
+				}
+			}
+		})
+	}
+}

--- a/internal/cmd/presence.go
+++ b/internal/cmd/presence.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var presenceCmd = &cobra.Command{
@@ -39,7 +38,7 @@ var presenceCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return output.Print(output.Format(viper.GetString("output")), []string{"present"}, []map[string]any{{"present": present}})
+		return printRows([]string{"present"}, []map[string]any{{"present": present}})
 	},
 }
 

--- a/internal/cmd/schedule.go
+++ b/internal/cmd/schedule.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var scheduleCmd = &cobra.Command{
@@ -33,7 +32,7 @@ var scheduleListCmd = &cobra.Command{
 			}
 			return err
 		}
-		return output.Print(output.Format(viper.GetString("output")), []string{"smart"}, []map[string]any{{"smart": smart}})
+		return printRows([]string{"smart"}, []map[string]any{{"smart": smart}})
 	},
 }
 

--- a/internal/cmd/sleep.go
+++ b/internal/cmd/sleep.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var sleepCmd = &cobra.Command{
@@ -52,8 +51,7 @@ var sleepDayCmd = &cobra.Command{
 				"hrv_score":      day.SleepQuality.HRV.Score,
 			},
 		}
-		rows = output.FilterFields(rows, viper.GetStringSlice("fields"))
-		return output.Print(output.Format(viper.GetString("output")), []string{"date", "score", "duration", "latency_asleep", "latency_out", "tnt", "resp_rate", "heart_rate", "hrv_score"}, rows)
+		return printRows([]string{"date", "score", "duration", "latency_asleep", "latency_out", "tnt", "resp_rate", "heart_rate", "hrv_score"}, rows)
 	},
 }
 

--- a/internal/cmd/sleep_range.go
+++ b/internal/cmd/sleep_range.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var sleepRangeCmd = &cobra.Command{
@@ -63,12 +62,8 @@ var sleepRangeCmd = &cobra.Command{
 				"hrv_score":  day.SleepQuality.HRV.Score,
 			})
 		}
-		rows = output.FilterFields(rows, viper.GetStringSlice("fields"))
 		headers := []string{"date", "score", "duration", "tnt", "resp_rate", "heart_rate", "hrv_score"}
-		if len(viper.GetStringSlice("fields")) > 0 {
-			headers = viper.GetStringSlice("fields")
-		}
-		return output.Print(output.Format(viper.GetString("output")), headers, rows)
+		return printRows(headers, rows)
 	},
 }
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var statusCmd = &cobra.Command{
@@ -48,12 +47,7 @@ var statusCmd = &cobra.Command{
 				return err
 			}
 		}
-		fields := viper.GetStringSlice("fields")
-		rows = output.FilterFields(rows, fields)
-		if len(fields) > 0 {
-			headers = fields
-		}
-		return output.Print(output.Format(viper.GetString("output")), headers, rows)
+		return printRows(headers, rows)
 	},
 }
 

--- a/internal/cmd/temp_modes.go
+++ b/internal/cmd/temp_modes.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var tempModeCmd = &cobra.Command{
@@ -51,12 +50,7 @@ var tempNapStatusCmd = &cobra.Command{Use: "status", RunE: func(cmd *cobra.Comma
 	if err := cl.TempModes().NapStatus(context.Background(), &out); err != nil {
 		return err
 	}
-	rows := output.FilterFields([]map[string]any{out}, viper.GetStringSlice("fields"))
-	headers := viper.GetStringSlice("fields")
-	if len(headers) == 0 {
-		headers = mapKeys(out)
-	}
-	return output.Print(output.Format(viper.GetString("output")), headers, rows)
+	return printRows(mapKeys(out), []map[string]any{out})
 }}
 
 var (
@@ -87,12 +81,7 @@ var tempHotStatusCmd = &cobra.Command{Use: "status", RunE: func(cmd *cobra.Comma
 	if err := cl.TempModes().HotFlashStatus(context.Background(), &out); err != nil {
 		return err
 	}
-	rows := output.FilterFields([]map[string]any{out}, viper.GetStringSlice("fields"))
-	headers := viper.GetStringSlice("fields")
-	if len(headers) == 0 {
-		headers = mapKeys(out)
-	}
-	return output.Print(output.Format(viper.GetString("output")), headers, rows)
+	return printRows(mapKeys(out), []map[string]any{out})
 }}
 
 var tempEventsCmd = &cobra.Command{Use: "events", RunE: func(cmd *cobra.Command, args []string) error {
@@ -106,13 +95,7 @@ var tempEventsCmd = &cobra.Command{Use: "events", RunE: func(cmd *cobra.Command,
 	if err := cl.TempModes().TempEvents(context.Background(), from, to, &out); err != nil {
 		return err
 	}
-	rows := []map[string]any{{"events": out}}
-	rows = output.FilterFields(rows, viper.GetStringSlice("fields"))
-	headers := viper.GetStringSlice("fields")
-	if len(headers) == 0 {
-		headers = mapKeys(rows[0])
-	}
-	return output.Print(output.Format(viper.GetString("output")), headers, rows)
+	return printRows([]string{"events"}, []map[string]any{{"events": out}})
 }}
 
 func init() {

--- a/internal/cmd/tracks.go
+++ b/internal/cmd/tracks.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var tracksCmd = &cobra.Command{
@@ -26,8 +25,6 @@ var tracksCmd = &cobra.Command{
 		for _, t := range tracks {
 			rows = append(rows, map[string]any{"id": t.ID, "title": t.Title, "type": t.Type})
 		}
-		fields := viper.GetStringSlice("fields")
-		rows = output.FilterFields(rows, fields)
-		return output.Print(output.Format(viper.GetString("output")), []string{"id", "title", "type"}, rows)
+		return printRows([]string{"id", "title", "type"}, rows)
 	},
 }

--- a/internal/cmd/travel.go
+++ b/internal/cmd/travel.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/steipete/eightctl/internal/client"
-	"github.com/steipete/eightctl/internal/output"
 )
 
 var travelCmd = &cobra.Command{Use: "travel", Short: "Travel / jetlag endpoints"}
@@ -22,7 +21,7 @@ var travelTripsCmd = &cobra.Command{Use: "trips", RunE: func(cmd *cobra.Command,
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"trips"}, []map[string]any{{"trips": res}})
+	return printRows([]string{"trips"}, []map[string]any{{"trips": res}})
 }}
 
 var travelCreateTripCmd = &cobra.Command{Use: "create-trip", RunE: func(cmd *cobra.Command, args []string) error {
@@ -71,7 +70,7 @@ var travelPlansCmd = &cobra.Command{Use: "plans", RunE: func(cmd *cobra.Command,
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"plans"}, []map[string]any{{"plans": res}})
+	return printRows([]string{"plans"}, []map[string]any{{"plans": res}})
 }}
 
 var travelCreatePlanCmd = &cobra.Command{Use: "create-plan", RunE: func(cmd *cobra.Command, args []string) error {
@@ -125,7 +124,7 @@ var travelTasksCmd = &cobra.Command{Use: "tasks", RunE: func(cmd *cobra.Command,
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"tasks"}, []map[string]any{{"tasks": res}})
+	return printRows([]string{"tasks"}, []map[string]any{{"tasks": res}})
 }}
 
 var travelAirportCmd = &cobra.Command{Use: "airport-search", RunE: func(cmd *cobra.Command, args []string) error {
@@ -138,7 +137,7 @@ var travelAirportCmd = &cobra.Command{Use: "airport-search", RunE: func(cmd *cob
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"airports"}, []map[string]any{{"airports": res}})
+	return printRows([]string{"airports"}, []map[string]any{{"airports": res}})
 }}
 
 var travelFlightCmd = &cobra.Command{Use: "flight-status", RunE: func(cmd *cobra.Command, args []string) error {
@@ -151,7 +150,7 @@ var travelFlightCmd = &cobra.Command{Use: "flight-status", RunE: func(cmd *cobra
 	if err != nil {
 		return err
 	}
-	return output.Print(output.Format(viper.GetString("output")), []string{"flight"}, []map[string]any{{"flight": res}})
+	return printRows([]string{"flight"}, []map[string]any{{"flight": res}})
 }}
 
 func init() {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -18,6 +18,14 @@ const (
 	FormatCSV   Format = "csv"
 )
 
+// PrintFields applies one field selection to both the rows and column order.
+func PrintFields(format Format, headers []string, rows []map[string]any, fields []string) error {
+	if len(fields) > 0 {
+		headers = fields
+	}
+	return Print(format, headers, FilterFields(rows, fields))
+}
+
 // Print renders rows according to format.
 // rows: slice of maps; headers define column order.
 func Print(format Format, headers []string, rows []map[string]any) error {


### PR DESCRIPTION
Several commands filtered row keys for --fields but kept all table/CSV headers, producing unselected columns filled with <nil>. Centralize field selection for both headers and rows in output.PrintFields and route all row-producing commands through one command helper. Preserve default columns and nested payloads; selection applies to top-level row fields.

Regression proof reproduced the old rendering as `date,score,duration` with `2026-09-12,88,<nil>`. Tests now verify selected columns and order in table, CSV and JSON. Existing command tests, lint and the 86.7% core coverage gate pass. Isolated Codex autoreview is scoped-clean at P0–P2.

Live proof: compiled a standalone program using the production output path and selected score,date. CSV prints `score,date` then `88,2026-09-12`; table has the same two columns in that order; JSON includes only date and score. The proof source is retained locally as output-proof.go; generated binaries are removed at closeout.
