### PR TITLE
fix: validate daemon schedules and own startup shutdown lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 ## Unreleased
 
 - Fixed logout leaving a usable cached session when email is omitted; reject ambiguous accounts without deleting tokens and recognize legacy/current keys for one account.
+- Fixed daemon startup accepting invalid schedules and racing on PID-file creation; dry-run needs no credentials, and shutdown cancels active requests.
 - Fixed `temp` ignoring persistent flags and requiring credentials for help; reject malformed temperatures and report explicit missing or malformed config files before commands run.
 - Fixed `--fields` leaving unselected columns and `<nil>` cells in table/CSV output; apply the same field selection to all row-producing commands.
 - Fixed alarm, audio, and Autopilot options being ignored when sibling commands registered flags with the same names; preserve flag, environment, and config precedence.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ An absent default config file is optional. An explicitly selected missing file o
 
 Preview scheduled actions without changing the pod, then remove `--dry-run` when the schedule is ready:
 
+Dry-run needs no account credentials. The daemon validates every schedule entry before starting, creates its PID file exclusively, and cancels active requests on shutdown. If a previous process was killed without cleanup, remove its stale PID file only after confirming that daemon is no longer running.
+
 ```sh
 eightctl daemon --config ~/.config/eightctl/config.yaml --dry-run
 ```

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -19,8 +20,10 @@ var daemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Run schedule daemon from config file",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireAuthFields(); err != nil {
-			return err
+		if !viper.GetBool("dry-run") {
+			if err := requireAuthFields(); err != nil {
+				return err
+			}
 		}
 		cfgData, err := readConfigSchedule()
 		if err != nil {
@@ -46,8 +49,8 @@ var daemonCmd = &cobra.Command{
 			Sync:     viper.GetBool("sync-state"),
 			PIDFile:  defaultPIDFile(viper.GetString("pid-file")),
 		}
-		ctx := context.Background()
-		fmt.Printf("daemon started with %d items\n", len(items))
+		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
 		return r.Run(ctx)
 	},
 }

--- a/internal/daemon/cancellation_test.go
+++ b/internal/daemon/cancellation_test.go
@@ -1,0 +1,47 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/99designs/keyring"
+	"github.com/steipete/eightctl/internal/client"
+	"github.com/steipete/eightctl/internal/tokencache"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestRunnerCancelsActiveRequest(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ring := keyring.NewArrayKeyring(nil)
+		t.Cleanup(tokencache.SetOpenKeyringForTest(func() (keyring.Keyring, error) { return ring, nil }))
+		t.Cleanup(tokencache.SetOpenFileKeyringForTest(func() (keyring.Keyring, error) { return ring, nil }))
+		c := client.New("fixture", "fixture", "uid", "", "")
+		if err := tokencache.Save(c.Identity(), "fixture", time.Now().Add(time.Hour), "uid"); err != nil {
+			t.Fatal(err)
+		}
+		started := make(chan struct{})
+		c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			close(started)
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		})}
+		r := Runner{Client: c, Timezone: time.UTC, Items: []ScheduleItem{{Time: time.Now().UTC().Add(time.Minute).Format("15:04"), Action: "on"}}}
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		done := make(chan error, 1)
+		go func() { done <- r.Run(ctx) }()
+		synctest.Wait()
+		time.Sleep(time.Minute)
+		<-started
+		cancel()
+		if err := <-done; err != nil {
+			t.Fatalf("graceful cancellation: %v", err)
+		}
+	})
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/steipete/eightctl/internal/client"
@@ -33,47 +31,52 @@ type Runner struct {
 }
 
 func (r *Runner) Run(ctx context.Context) error {
+	items, err := prepareSchedule(r.Items)
+	if err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+	if r.Timezone == nil {
+		r.Timezone = time.Local
+	}
 	if err := r.writePID(); err != nil {
 		return err
 	}
 	defer r.removePID()
+	fmt.Printf("daemon started with %d items\n", len(items))
 
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 
 	executed := map[string]bool{}
-	day := time.Now().Day()
-
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	day := time.Now().In(r.Timezone).Format(time.DateOnly)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-sig:
-			return nil
 		case now := <-ticker.C:
-			if now.Day() != day {
+			if date := now.In(r.Timezone).Format(time.DateOnly); date != day {
 				executed = map[string]bool{}
-				day = now.Day()
+				day = date
 			}
-			if err := r.process(now, executed); err != nil {
+			if err := r.process(ctx, now, executed, items); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
 				return err
 			}
 		}
 	}
 }
 
-func (r *Runner) process(now time.Time, executed map[string]bool) error {
+func (r *Runner) process(ctx context.Context, now time.Time, executed map[string]bool, items []timedAction) error {
 	// Ticker timestamps use the host zone; schedules use their configured date.
 	now = now.In(r.Timezone)
-	for _, item := range r.Items {
-		t, err := time.ParseInLocation("15:04", item.Time, r.Timezone)
-		if err != nil {
-			return fmt.Errorf("parse time %s: %w", item.Time, err)
-		}
-		candidate := time.Date(now.Year(), now.Month(), now.Day(), t.Hour(), t.Minute(), 0, 0, r.Timezone)
+	for _, item := range items {
+		candidate := time.Date(now.Year(), now.Month(), now.Day(), item.hour, item.minute, 0, 0, r.Timezone)
 		if now.Before(candidate) || now.Sub(candidate) >= time.Minute {
 			continue
 		}
@@ -88,23 +91,17 @@ func (r *Runner) process(now time.Time, executed map[string]bool) error {
 		}
 		switch item.Action {
 		case "on":
-			if err := r.Client.TurnOn(context.Background()); err != nil {
+			if err := r.Client.TurnOn(ctx); err != nil {
 				return err
 			}
 		case "off":
-			if err := r.Client.TurnOff(context.Background()); err != nil {
+			if err := r.Client.TurnOff(ctx); err != nil {
 				return err
 			}
 		case "temp":
-			level, err := ParseTemp(item.Temperature)
-			if err != nil {
+			if err := r.Client.SetTemperature(ctx, item.level); err != nil {
 				return err
 			}
-			if err := r.Client.SetTemperature(context.Background(), level); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("unknown action %s", item.Action)
 		}
 	}
 	return nil
@@ -117,13 +114,21 @@ func (r *Runner) writePID() error {
 	if err := os.MkdirAll(filepath.Dir(r.PIDFile), 0o755); err != nil {
 		return err
 	}
-	if data, err := os.ReadFile(r.PIDFile); err == nil {
-		pid := strings.TrimSpace(string(data))
-		if pid != "" {
-			return fmt.Errorf("daemon already running (pid %s)", pid)
-		}
+	file, err := os.OpenFile(r.PIDFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create daemon PID file: %w", err)
 	}
-	return os.WriteFile(r.PIDFile, []byte(fmt.Sprint(os.Getpid())), 0o600)
+	_, writeErr := fmt.Fprint(file, os.Getpid())
+	closeErr := file.Close()
+	if writeErr != nil {
+		r.removePID()
+		return writeErr
+	}
+	if closeErr != nil {
+		r.removePID()
+		return closeErr
+	}
+	return nil
 }
 
 func (r *Runner) removePID() {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -75,10 +75,10 @@ func TestRunnerProcessExecutesDueItemsOnce(t *testing.T) {
 		Timezone: time.UTC,
 	}
 	executed := map[string]bool{}
-	if err := r.process(now, executed); err != nil {
+	if err := processAt(&r, now, executed); err != nil {
 		t.Fatalf("process: %v", err)
 	}
-	if err := r.process(now, executed); err != nil {
+	if err := processAt(&r, now, executed); err != nil {
 		t.Fatalf("process second pass: %v", err)
 	}
 	if got, want := strings.Join(requests, ","), strings.Join([]string{
@@ -122,7 +122,7 @@ func TestRunnerProcessUsesScheduleDate(t *testing.T) {
 				DryRun:   true,
 			}
 			executed := map[string]bool{}
-			if err := r.process(tt.now, executed); err != nil {
+			if err := processAt(&r, tt.now, executed); err != nil {
 				t.Fatal(err)
 			}
 			if !executed[tt.key] {
@@ -151,16 +151,16 @@ func useTempKeyring(t *testing.T) {
 
 func TestRunnerProcessErrors(t *testing.T) {
 	r := Runner{Timezone: time.UTC}
-	if err := r.process(time.Now(), map[string]bool{}); err != nil {
+	if err := processAt(&r, time.Now(), map[string]bool{}); err != nil {
 		t.Fatalf("empty process: %v", err)
 	}
 	r.Items = []ScheduleItem{{Time: "bad", Action: "on"}}
-	if err := r.process(time.Now(), map[string]bool{}); err == nil {
+	if err := processAt(&r, time.Now(), map[string]bool{}); err == nil {
 		t.Fatalf("expected bad time error")
 	}
 	r.Items = []ScheduleItem{{Time: "07:30", Action: "bogus"}}
 	now := time.Date(2026, 4, 22, 7, 30, 0, 0, time.UTC)
-	if err := r.process(now, map[string]bool{}); err == nil {
+	if err := processAt(&r, now, map[string]bool{}); err == nil {
 		t.Fatalf("expected unknown action error")
 	}
 }
@@ -196,9 +196,49 @@ func TestRunnerRunStopsWhenContextCanceled(t *testing.T) {
 	}
 }
 
+func TestRunnerRejectsInvalidScheduleBeforeStarting(t *testing.T) {
+	for _, item := range []ScheduleItem{
+		{Time: "23:59", Action: "unknown"},
+		{Time: "23:59", Action: "temp", Temperature: "bad"},
+		{Time: "bad", Action: "on"},
+	} {
+		r := Runner{Items: []ScheduleItem{item}, DryRun: true, PIDFile: filepath.Join(t.TempDir(), "daemon.pid")}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		if err := r.Run(ctx); err == nil {
+			t.Errorf("invalid schedule accepted: %+v", item)
+		}
+		if _, err := os.Stat(r.PIDFile); !os.IsNotExist(err) {
+			t.Fatal("invalid schedule created a PID file")
+		}
+	}
+}
+
+func TestRunnerDoesNotOverwriteExistingPIDFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "daemon.pid")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := Runner{PIDFile: path}
+	if err := r.writePID(); err == nil {
+		t.Fatal("overwrote an existing PID file")
+	}
+	if data, err := os.ReadFile(path); err != nil || len(data) != 0 {
+		t.Fatalf("existing file changed: %q %v", data, err)
+	}
+}
+
 func ExampleParseTemp() {
 	level, _ := ParseTemp("68F")
 	fmt.Println(level)
 	// Output:
 	// -42
+}
+
+func processAt(r *Runner, now time.Time, executed map[string]bool) error {
+	items, err := prepareSchedule(r.Items)
+	if err != nil {
+		return err
+	}
+	return r.process(context.Background(), now, executed, items)
 }

--- a/internal/daemon/schedule.go
+++ b/internal/daemon/schedule.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"fmt"
+	"time"
+)
+
+type timedAction struct {
+	ScheduleItem
+	hour, minute int
+	level        int
+}
+
+func prepareSchedule(items []ScheduleItem) ([]timedAction, error) {
+	prepared := make([]timedAction, 0, len(items))
+	for _, item := range items {
+		at, err := time.Parse("15:04", item.Time)
+		if err != nil {
+			return nil, fmt.Errorf("parse time %s: %w", item.Time, err)
+		}
+		action := timedAction{ScheduleItem: item, hour: at.Hour(), minute: at.Minute()}
+		switch item.Action {
+		case "on", "off":
+		case "temp":
+			action.level, err = ParseTemp(item.Temperature)
+			if err != nil {
+				return nil, fmt.Errorf("schedule %s: %w", item.Time, err)
+			}
+		default:
+			return nil, fmt.Errorf("unknown action %s", item.Action)
+		}
+		prepared = append(prepared, action)
+	}
+	return prepared, nil
+}


### PR DESCRIPTION
The daemon validated actions only when their minute arrived, skipped validation in dry-run, raced between PID-file checking and writing, and detached API calls from shutdown cancellation. Compile and validate the full schedule before startup, create the PID file exclusively, and carry the caller's context through active requests. The CLI owns signal registration and unregisters it on exit; dry-run no longer needs account credentials.

Regressions reproduced invalid schedules being accepted and an existing empty PID file being overwritten. The suite, daemon race tests, lint, and 87.5% core coverage pass. Virtual-time coverage confirms shutdown cancels an active request. Final isolated Codex autoreview is scoped-clean at P0–P2; an earlier missing-context finding about the existing empty-PID guard was resolved by supplying the full source, without changing the valid test.

Live production CLI proof: an invalid future action fails before startup or PID creation; a valid dry-run starts without credentials, exits successfully on SIGTERM, and removes its PID file; an existing PID file is preserved. All checks passed without provider traffic.
