### PR TITLE
fix: preserve resolved user identity in control and whoami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 
 ## Unreleased
 
+- Fixed malformed household user responses silently falling back to the authenticated user's side; reject missing or mismatched discovered IDs.
+- Fixed `whoami` unnecessarily logging in again instead of reusing the configured or cached user ID.
 - Fixed logout leaving a usable cached session when email is omitted; reject ambiguous accounts without deleting tokens and recognize legacy/current keys for one account.
 - Fixed daemon startup accepting invalid schedules and racing on PID-file creation; dry-run needs no credentials, and shutdown cancels active requests.
 - Fixed `temp` ignoring persistent flags and requiring credentials for help; reject malformed temperatures and report explicit missing or malformed config files before commands run.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ eightctl temp -40 --side right
 
 `status`, `on`, `off`, and `temp` act on all discovered household sides unless you select one with `--side left|right|solo` or `--target-user-id <id>`.
 
+Discovery fails explicitly if a household user response omits its ID or returns a different ID; commands do not substitute the authenticated user's side for a malformed target. `whoami` reuses the configured or cached user ID, resolving it from the API only when needed.
+
 ## Commands
 
 | Area | Commands |

--- a/internal/client/target_identity_test.go
+++ b/internal/client/target_identity_test.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHouseholdTargetsRejectInvalidUserIdentity(t *testing.T) {
+	for _, id := range []string{"", "different-user"} {
+		t.Run(id, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/devices/dev" {
+					w.Write([]byte(`{"result":{"leftUserId":"expected-user"}}`))
+					return
+				}
+				json.NewEncoder(w).Encode(map[string]any{"user": map[string]string{"userId": id}})
+			}))
+			defer server.Close()
+			c := New("fixture", "fixture", "authenticated-user", "", "")
+			c.BaseURL, c.DeviceID, c.HTTP = server.URL, "dev", server.Client()
+			c.token, c.tokenExp = "fixture", time.Now().Add(time.Hour)
+			if targets, err := c.HouseholdUserTargets(t.Context()); !errors.Is(err, ErrInvalidHouseholdUser) || targets != nil {
+				t.Fatalf("targets=%v error=%v", targets, err)
+			}
+		})
+	}
+}

--- a/internal/client/targets.go
+++ b/internal/client/targets.go
@@ -2,12 +2,15 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
 	"strings"
 )
+
+var ErrInvalidHouseholdUser = errors.New("invalid household user response")
 
 // HouseholdUserTarget describes a user that can be targeted for side-aware actions.
 type HouseholdUserTarget struct {
@@ -80,6 +83,12 @@ func (c *Client) HouseholdUserTargets(ctx context.Context) ([]HouseholdUserTarge
 		}
 		if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/users/%s", userID), nil, nil, &userRes); err != nil {
 			return nil, err
+		}
+		if userRes.User.UserID == "" {
+			return nil, fmt.Errorf("%w: household user is missing a user ID", ErrInvalidHouseholdUser)
+		}
+		if userRes.User.UserID != userID {
+			return nil, fmt.Errorf("%w: requested %q, received %q", ErrInvalidHouseholdUser, userID, userRes.User.UserID)
 		}
 		targets = append(targets, HouseholdUserTarget{
 			UserID:    userRes.User.UserID,

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -72,6 +73,9 @@ func defaultStatusRows(ctx context.Context, cl *client.Client, target *client.Ho
 	}
 
 	targets, err := cl.HouseholdUserTargets(ctx)
+	if errors.Is(err, client.ErrInvalidHouseholdUser) {
+		return nil, nil, err
+	}
 	if err == nil && len(targets) > 0 {
 		rows, err := householdStatusRows(ctx, cl, targets)
 		if err != nil {

--- a/internal/cmd/target_identity_test.go
+++ b/internal/cmd/target_identity_test.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/eightctl/internal/client"
+	"github.com/steipete/eightctl/internal/tokencache"
+)
+
+func TestInvalidHouseholdIdentityDoesNotFallBackToAuthenticatedUser(t *testing.T) {
+	useTempKeyring(t)
+	requests := make(chan string, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.Path
+		if r.URL.Path == "/devices/dev" {
+			w.Write([]byte(`{"result":{"leftUserId":"selected-user"}}`))
+		} else {
+			w.Write([]byte(`{"user":{}}`))
+		}
+	}))
+	defer server.Close()
+	c := client.New("fixture", "fixture", "authenticated-user", "", "")
+	c.BaseURL, c.AppURL, c.DeviceID, c.HTTP = server.URL, server.URL, "dev", server.Client()
+	if err := tokencache.Save(c.Identity(), "fixture", time.Now().Add(time.Hour), c.UserID); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := resolveCommandTargetValues(t.Context(), c, "", ""); !errors.Is(err, client.ErrInvalidHouseholdUser) {
+		t.Fatalf("control resolution: %v", err)
+	}
+	if _, _, err := defaultStatusRows(t.Context(), c, nil); !errors.Is(err, client.ErrInvalidHouseholdUser) {
+		t.Fatalf("status resolution: %v", err)
+	}
+	close(requests)
+	for path := range requests {
+		if strings.Contains(path, "temperature") {
+			t.Fatalf("fell back to a different target: %s", path)
+		}
+	}
+}

--- a/internal/cmd/targeting.go
+++ b/internal/cmd/targeting.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -81,6 +82,9 @@ func resolveCommandTargetValues(ctx context.Context, cl *client.Client, targetUs
 	}
 
 	targets, err := cl.HouseholdUserTargets(ctx)
+	if errors.Is(err, client.ErrInvalidHouseholdUser) {
+		return nil, false, err
+	}
 	if err != nil || len(targets) == 0 {
 		return nil, false, nil
 	}

--- a/internal/cmd/whoami.go
+++ b/internal/cmd/whoami.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -18,7 +17,7 @@ var whoamiCmd = &cobra.Command{
 			return err
 		}
 		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
-		if err := cl.Authenticate(context.Background()); err != nil {
+		if err := cl.EnsureUserID(cmd.Context()); err != nil {
 			return err
 		}
 		fmt.Printf("UserID: %s\n", cl.UserID)

--- a/internal/cmd/whoami_test.go
+++ b/internal/cmd/whoami_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/eightctl/internal/client"
+	"github.com/steipete/eightctl/internal/tokencache"
+)
+
+func TestWhoamiUsesCachedIdentity(t *testing.T) {
+	if os.Getenv("EIGHTCTL_TEST_WHOAMI") != "1" {
+		command := exec.Command(os.Args[0], "-test.run=^TestWhoamiUsesCachedIdentity$")
+		for _, variable := range os.Environ() {
+			if !strings.HasPrefix(variable, "EIGHTCTL_") {
+				command.Env = append(command.Env, variable)
+			}
+		}
+		command.Env = append(command.Env, "EIGHTCTL_TEST_WHOAMI=1")
+		if out, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("whoami: %v\n%s", err, out)
+		}
+		return
+	}
+	useTempKeyring(t)
+	resetViper(t)
+	c := client.New("", "", "", "", "")
+	if err := tokencache.Save(c.Identity(), "fixture", time.Now().Add(time.Hour), "cached-user"); err != nil {
+		t.Fatal(err)
+	}
+	requests := make(chan struct{}, 4)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- struct{}{}
+		http.Error(w, "unexpected provider request blocked", http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+	text, err := captureAwayStatus(t, func() error { return whoamiCmd.RunE(whoamiCmd, nil) })
+	if err != nil || text != "UserID: cached-user\n" || len(requests) != 0 {
+		t.Fatalf("output=%q error=%v requests=%d", text, err, len(requests))
+	}
+}


### PR DESCRIPTION
A missing household user ID was interpreted by downstream controls as 'use the authenticated user', and mismatched response IDs could select a different person. Reject malformed identities during discovery and propagate that specific error through default control/status resolution. Preserve the existing fallback for unavailable discovery and explicit user targeting.

Also make whoami resolve the configured/cached user ID instead of unconditionally issuing another password grant. Regression tests reproduced missing/mismatched IDs being accepted and cached whoami attempting a blocked provider login. Client/command tests, race tests and lint pass; isolated Codex autoreview is scoped-clean at P0–P2.

Live proof: a production CLI built with Go 1.26.8/CGO disabled prints `UserID: configured-user` with synthetic credentials and an unreachable HTTPS proxy, demonstrating no login is needed. A separately built program uses the production client against a local HTTP server returning a malformed user response and verifies the typed identity error before any control action (PASS). Default-control/status regression tests also verify no temperature fallback request occurs.
