### PR TITLE
fix: use query timezone and calendar dates for sleep windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 - Fixed logout leaving a usable cached session when email is omitted; reject ambiguous accounts without deleting tokens and recognize legacy/current keys for one account.
 - Fixed daemon startup accepting invalid schedules and racing on PID-file creation; dry-run needs no credentials, and shutdown cancels active requests.
 - Fixed `temp` ignoring persistent flags and requiring credentials for help; reject malformed temperatures and report explicit missing or malformed config files before commands run.
+- Fixed default sleep/presence dates using the host timezone and presence windows skipping a calendar day across DST; include timezone data in standalone builds.
 - Fixed `--fields` leaving unselected columns and `<nil>` cells in table/CSV output; apply the same field selection to all row-producing commands.
 - Fixed alarm, audio, and Autopilot options being ignored when sibling commands registered flags with the same names; preserve flag, environment, and config precedence.
 - Fixed API retries delaying cancellation, retaining response bodies, and reusing rejected tokens when cache deletion fails.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Keep the file readable only by your account with `chmod 600 ~/.config/eightctl/c
 
 Schedule times and dates use the configured `timezone`, even when it differs from the host timezone.
 
+Default sleep/presence dates also use that timezone. Presence queries default to yesterday through today as calendar dates, including across daylight-saving transitions. Standalone binaries include IANA timezone data.
+
 An absent default config file is optional. An explicitly selected missing file or malformed YAML is an error. Temperature values must be complete integer levels from -100 to 100, or finite numbers ending in `F` or `C`; persistent flags also work after `temp`, including with negative values.
 
 Preview scheduled actions without changing the pod, then remove `--dry-run` when the schedule is ready:

--- a/internal/client/presence.go
+++ b/internal/client/presence.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+	_ "time/tzdata"
 )
 
 type trendSample struct {
@@ -28,10 +29,15 @@ func (c *Client) GetPresence(ctx context.Context, from, to, timezone string) (bo
 		return false, err
 	}
 
-	now := time.Now()
+	tz := resolveTZ(timezone)
+	location, err := time.LoadLocation(tz)
+	if err != nil {
+		return false, fmt.Errorf("load timezone %q: %w", tz, err)
+	}
+	now := time.Now().In(location)
 	from, to = resolvePresenceWindow(now, from, to)
 	q := url.Values{}
-	q.Set("tz", resolveTZ(timezone))
+	q.Set("tz", tz)
 	q.Set("from", from)
 	q.Set("to", to)
 	q.Set("include-main", "false")
@@ -50,7 +56,7 @@ func resolvePresenceWindow(now time.Time, from, to string) (string, string) {
 	const layout = "2006-01-02"
 
 	if from == "" && to == "" {
-		return now.Add(-24 * time.Hour).Format(layout), now.Format(layout)
+		return now.AddDate(0, 0, -1).Format(layout), now.Format(layout)
 	}
 	if to == "" {
 		return from, now.Format(layout)
@@ -60,7 +66,7 @@ func resolvePresenceWindow(now time.Time, from, to string) (string, string) {
 		if err != nil {
 			return from, to
 		}
-		return end.Add(-24 * time.Hour).Format(layout), to
+		return end.AddDate(0, 0, -1).Format(layout), to
 	}
 	return from, to
 }

--- a/internal/client/presence_test.go
+++ b/internal/client/presence_test.go
@@ -2,11 +2,46 @@ package client
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 )
+
+func TestPresenceDefaultsUseConfiguredDate(t *testing.T) {
+	previous := time.Local
+	time.Local = time.UTC
+	t.Cleanup(func() { time.Local = previous })
+	synctest.Test(t, func(t *testing.T) {
+		c := New("fixture", "fixture", "uid", "", "")
+		c.token, c.tokenExp = "fixture", time.Now().Add(time.Hour)
+		c.HTTP = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			q := req.URL.Query()
+			if q.Get("from") != "1999-12-30" || q.Get("to") != "1999-12-31" || q.Get("tz") != "America/Los_Angeles" {
+				t.Errorf("date window = %s", q.Encode())
+			}
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"days":[]}`))}, nil
+		})}
+		if _, err := c.GetPresence(t.Context(), "", "", "America/Los_Angeles"); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestPresenceWindowUsesCalendarDaysAcrossDST(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 3, 9, 0, 30, 0, 0, loc)
+	from, to := resolvePresenceWindow(now, "", "")
+	if from != "2026-03-08" || to != "2026-03-09" {
+		t.Fatalf("window = %s..%s", from, to)
+	}
+}
 
 func TestPresenceFromTrendDays(t *testing.T) {
 	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -141,8 +141,8 @@ func TestMapKeysAndCurrentDate(t *testing.T) {
 	if got := mapKeys(map[string]any{"b": 2, "a": 1}); !reflect.DeepEqual(got, []string{"a", "b"}) {
 		t.Fatalf("mapKeys = %#v", got)
 	}
-	if got := currentDate(); len(got) != len("2006-01-02") {
-		t.Fatalf("currentDate = %q", got)
+	if got, err := currentDate("UTC"); err != nil || len(got) != len("2006-01-02") {
+		t.Fatalf("currentDate = %q, error = %v", got, err)
 	}
 }
 

--- a/internal/cmd/sleep.go
+++ b/internal/cmd/sleep.go
@@ -26,12 +26,15 @@ var sleepDayCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if date == "" {
-			date = currentDate()
-		}
 		tz, err := resolveAPITimezone(viper.GetString("timezone"))
 		if err != nil {
 			return err
+		}
+		if date == "" {
+			date, err = currentDate(tz)
+			if err != nil {
+				return err
+			}
 		}
 		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
 		day, err := cl.GetSleepDay(context.Background(), date, tz)

--- a/internal/cmd/timezone.go
+++ b/internal/cmd/timezone.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -63,6 +64,10 @@ func extractZoneinfoSuffix(path string) string {
 	return ""
 }
 
-func currentDate() string {
-	return time.Now().Format("2006-01-02")
+func currentDate(timezone string) (string, error) {
+	location, err := time.LoadLocation(timezone)
+	if err != nil {
+		return "", fmt.Errorf("load timezone %q: %w", timezone, err)
+	}
+	return time.Now().In(location).Format(time.DateOnly), nil
 }

--- a/internal/cmd/timezone_test.go
+++ b/internal/cmd/timezone_test.go
@@ -2,8 +2,24 @@ package cmd
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 )
+
+func TestCurrentDateUsesConfiguredTimezone(t *testing.T) {
+	oldLocal := time.Local
+	time.Local = time.UTC
+	t.Cleanup(func() { time.Local = oldLocal })
+	synctest.Test(t, func(t *testing.T) {
+		date, err := currentDate("America/Los_Angeles")
+		if err != nil || date != "1999-12-31" {
+			t.Fatalf("date=%s error=%v", date, err)
+		}
+		if _, err := currentDate("invalid/timezone"); err == nil {
+			t.Fatal("invalid timezone accepted")
+		}
+	})
+}
 
 func TestResolveAPITimezoneExplicit(t *testing.T) {
 	got, err := resolveAPITimezone("America/New_York")


### PR DESCRIPTION
Default sleep and presence queries used the host date even when --timezone selected another date, and subtracting 24 hours could skip a calendar day across spring-forward. Resolve dates in the query timezone and subtract calendar days. Keep explicit ranges unchanged and embed standard-library timezone data for standalone binaries.

Regressions reproduced a Los Angeles query using the UTC date and a New York spring-forward window spanning March 7–9 instead of March 8–9. The suite, shuffled integrated tests, lint and 86.8% core coverage pass. Isolated Codex autoreview is scoped-clean at P0–P2.

Live proof: built a standalone program using the production client against a local HTTP server. On the Pacific host it sent `from=2026-09-12 to=2026-09-13 timezone=Asia/Tokyo`, matching Tokyo's calendar dates (PASS). The retained date-proof.go uses only synthetic credentials and memory-backed token stores.
