### PR TITLE
fix: allow whoami to display configured identities offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The first tagged release is 0.2.0; the 0.1.0 section reconstructs earlier projec
 ## Unreleased
 
 - Fixed malformed household user responses silently falling back to the authenticated user's side; reject missing or mismatched discovered IDs.
-- Fixed `whoami` unnecessarily logging in again instead of reusing the configured or cached user ID.
+- Fixed `whoami` unnecessarily logging in again instead of reusing the configured or cached user ID; an already configured ID can be printed without credentials.
 - Fixed logout leaving a usable cached session when email is omitted; reject ambiguous accounts without deleting tokens and recognize legacy/current keys for one account.
 - Fixed daemon startup accepting invalid schedules and racing on PID-file creation; dry-run needs no credentials, and shutdown cancels active requests.
 - Fixed `temp` ignoring persistent flags and requiring credentials for help; reject malformed temperatures and report explicit missing or malformed config files before commands run.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ eightctl temp -40 --side right
 
 Discovery fails explicitly if a household user response omits its ID or returns a different ID; commands do not substitute the authenticated user's side for a malformed target. `whoami` reuses the configured or cached user ID, resolving it from the API only when needed.
 
+`eightctl --user-id <id> whoami` can display that configured ID offline without account credentials.
+
 ## Commands
 
 | Area | Commands |

--- a/internal/cmd/whoami.go
+++ b/internal/cmd/whoami.go
@@ -13,8 +13,10 @@ var whoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "Show configured user ID",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireAuthFields(); err != nil {
-			return err
+		if viper.GetString("user_id") == "" {
+			if err := requireAuthFields(); err != nil {
+				return err
+			}
 		}
 		cl := client.New(viper.GetString("email"), viper.GetString("password"), viper.GetString("user_id"), viper.GetString("client_id"), viper.GetString("client_secret"))
 		if err := cl.EnsureUserID(cmd.Context()); err != nil {

--- a/internal/cmd/whoami_test.go
+++ b/internal/cmd/whoami_test.go
@@ -9,29 +9,37 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/steipete/eightctl/internal/client"
 	"github.com/steipete/eightctl/internal/tokencache"
 )
 
-func TestWhoamiUsesCachedIdentity(t *testing.T) {
-	if os.Getenv("EIGHTCTL_TEST_WHOAMI") != "1" {
-		command := exec.Command(os.Args[0], "-test.run=^TestWhoamiUsesCachedIdentity$")
-		for _, variable := range os.Environ() {
-			if !strings.HasPrefix(variable, "EIGHTCTL_") {
-				command.Env = append(command.Env, variable)
+func TestWhoamiUsesResolvedIdentity(t *testing.T) {
+	mode := os.Getenv("EIGHTCTL_TEST_WHOAMI")
+	if mode == "" {
+		for _, mode := range []string{"cached", "configured"} {
+			command := exec.Command(os.Args[0], "-test.run=^TestWhoamiUsesResolvedIdentity$")
+			for _, variable := range os.Environ() {
+				if !strings.HasPrefix(variable, "EIGHTCTL_") {
+					command.Env = append(command.Env, variable)
+				}
 			}
-		}
-		command.Env = append(command.Env, "EIGHTCTL_TEST_WHOAMI=1")
-		if out, err := command.CombinedOutput(); err != nil {
-			t.Fatalf("whoami: %v\n%s", err, out)
+			command.Env = append(command.Env, "EIGHTCTL_TEST_WHOAMI="+mode)
+			if out, err := command.CombinedOutput(); err != nil {
+				t.Errorf("%s whoami: %v\n%s", mode, err, out)
+			}
 		}
 		return
 	}
 	useTempKeyring(t)
 	resetViper(t)
-	c := client.New("", "", "", "", "")
-	if err := tokencache.Save(c.Identity(), "fixture", time.Now().Add(time.Hour), "cached-user"); err != nil {
-		t.Fatal(err)
+	if mode == "cached" {
+		c := client.New("", "", "", "", "")
+		if err := tokencache.Save(c.Identity(), "fixture", time.Now().Add(time.Hour), "cached-user"); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		viper.Set("user_id", "configured-user")
 	}
 	requests := make(chan struct{}, 4)
 	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +50,7 @@ func TestWhoamiUsesCachedIdentity(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", proxy.URL)
 	t.Setenv("NO_PROXY", "")
 	text, err := captureAwayStatus(t, func() error { return whoamiCmd.RunE(whoamiCmd, nil) })
-	if err != nil || text != "UserID: cached-user\n" || len(requests) != 0 {
+	if err != nil || text != "UserID: "+mode+"-user\n" || len(requests) != 0 {
 		t.Fatalf("output=%q error=%v requests=%d", text, err, len(requests))
 	}
 }


### PR DESCRIPTION
Final audit found that whoami still required a token or credentials even when --user-id already provided the identity to display. Skip authentication preconditions for an already configured ID; use cached/API resolution when the ID is absent.

The expanded fresh-process regression reproduced the configured-ID failure without credentials and now checks both cached and configured identity paths with zero network requests. All Go tests and lint pass. Isolated Codex autoreview is scoped-clean at P0–P2.

Live production CLI proof: with EIGHTCTL_* environment variables removed and no account credentials, `eightctl --config <synthetic.yaml> --quiet --user-id offline-user whoami` prints `UserID: offline-user` and exits successfully.
